### PR TITLE
Make import paths file-relative and migrate all examples

### DIFF
--- a/Book/2/2_12_DoubleOTP.scheme
+++ b/Book/2/2_12_DoubleOTP.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Scheme DoubleOTP(Int lambda) extends SymEnc {
     Set Message = BitString<lambda>;

--- a/Book/2/2_13.proof
+++ b/Book/2/2_13.proof
@@ -1,6 +1,6 @@
-import 'examples/Book/2/2_12_DoubleOTP.scheme';
-import 'examples/Games/Misc/OTPUniform.game';
-import 'examples/Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Book/2/2_12_DoubleOTP.scheme';
+import '../../Games/Misc/OTPUniform.game';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
 
 Reduction R1(DoubleOTP D, Int lambda) compose OTPUniform(lambda) against OneTimeUniformCiphertexts(D).Adversary {
     D.Ciphertext CTXT(D.Message m) {

--- a/Book/2_Exercises/2_13.proof
+++ b/Book/2_Exercises/2_13.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Book/2_Exercises/2_13_SymEncSquared.scheme';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Book/2_Exercises/2_13_SymEncSquared.scheme';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
 
 Reduction R(SymEncSquared S, SymEnc E) 
 compose OneTimeSecrecy(E) against OneTimeSecrecy(S).Adversary {

--- a/Book/2_Exercises/2_13_SymEncSquared.scheme
+++ b/Book/2_Exercises/2_13_SymEncSquared.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Scheme SymEncSquared(SymEnc E) extends SymEnc {
     Set Message = E.Message;

--- a/Book/2_Exercises/2_14.game
+++ b/Book/2_Exercises/2_14.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {
     E.Ciphertext Foo(E.Message m) {

--- a/Book/2_Exercises/2_14_Backward.proof
+++ b/Book/2_Exercises/2_14_Backward.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Book/2_Exercises/2_14.game';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Book/2_Exercises/2_14.game';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
 
 Reduction R1(SymEnc E) compose Foo(E) against OneTimeSecrecy(E).Adversary {
     E.Ciphertext Eavesdrop(E.Message mL, E.Message mR) {

--- a/Book/2_Exercises/2_14_Forward.proof
+++ b/Book/2_Exercises/2_14_Forward.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Book/2_Exercises/2_14.game';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Book/2_Exercises/2_14.game';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
 
 Reduction R(SymEnc E) compose OneTimeSecrecy(E) against Foo(E).Adversary {
     E.Ciphertext Foo(E.Message m) {

--- a/Book/2_Exercises/2_15.game
+++ b/Book/2_Exercises/2_15.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {
     E.Ciphertext * E.Ciphertext Foo(E.Message mL, E.Message mR) {

--- a/Book/2_Exercises/2_15_Backward.proof
+++ b/Book/2_Exercises/2_15_Backward.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Book/2_Exercises/2_15.game';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Book/2_Exercises/2_15.game';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
 
 Reduction R(SymEnc E) compose Foo(E) against OneTimeSecrecy(E).Adversary {
     E.Ciphertext Eavesdrop(E.Message mL, E.Message mR) {

--- a/Book/2_Exercises/2_15_Forward.proof
+++ b/Book/2_Exercises/2_15_Forward.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Book/2_Exercises/2_15.game';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Book/2_Exercises/2_15.game';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
 
 Reduction R(SymEnc E) compose OneTimeSecrecy(E) against Foo(E).Adversary {
     E.Ciphertext * E.Ciphertext Foo(E.Message mL, E.Message mR) {

--- a/Book/5/5_2_PseudoOTP.scheme
+++ b/Book/5/5_2_PseudoOTP.scheme
@@ -1,5 +1,5 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Primitives/PRG.primitive';
+import '../../Primitives/SymEnc.primitive';
+import '../../Primitives/PRG.primitive';
 
 Scheme PseudoOTP(Int lambda, Int stretch, PRG G) extends SymEnc {
     requires G.lambda == lambda && G.stretch == stretch;

--- a/Book/5/5_3.proof
+++ b/Book/5/5_3.proof
@@ -1,8 +1,8 @@
-import 'examples/Book/5/5_2_PseudoOTP.scheme';
-import 'examples/Primitives/PRG.primitive';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
-import 'examples/Games/PRG/Security.game';
-import 'examples/Games/Misc/OTPOTS.game';
+import '../../Book/5/5_2_PseudoOTP.scheme';
+import '../../Primitives/PRG.primitive';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
+import '../../Games/PRG/Security.game';
+import '../../Games/Misc/OTPOTS.game';
 
 Reduction R1(PseudoOTP P, PRG G) compose Security(G) against OneTimeSecrecy(P).Adversary {
     P.Ciphertext Eavesdrop(P.Message mL, P.Message mR) {

--- a/Book/5_Exercises/5_10.proof
+++ b/Book/5_Exercises/5_10.proof
@@ -1,9 +1,9 @@
-import 'examples/Primitives/PRG.primitive';
-import 'examples/Book/5_Exercises/5_10.scheme';
-import 'examples/Schemes/SymEnc/OTP.scheme';
-import 'examples/Games/Misc/BitStringSampling.game';
-import 'examples/Games/PRG/Security.game';
-import 'examples/Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Primitives/PRG.primitive';
+import '../../Book/5_Exercises/5_10.scheme';
+import '../../Schemes/SymEnc/OTP.scheme';
+import '../../Games/Misc/BitStringSampling.game';
+import '../../Games/PRG/Security.game';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
 
 Reduction R1(PRG G, PRG_5_10 H) compose Security(G) against Security(H).Adversary {
     BitString<H.lambda + H.stretch> Query() {

--- a/Book/5_Exercises/5_10.scheme
+++ b/Book/5_Exercises/5_10.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRG.primitive';
+import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_10(PRG G) extends PRG {
     requires G.stretch == G.lambda;

--- a/Book/5_Exercises/5_8_PseudoOTP_OTUC.proof
+++ b/Book/5_Exercises/5_8_PseudoOTP_OTUC.proof
@@ -1,8 +1,8 @@
-import 'examples/Primitives/PRG.primitive';
-import 'examples/Book/5/5_2_PseudoOTP.scheme';
-import 'examples/Games/SymEnc/OneTimeUniformCiphertexts.game';
-import 'examples/Games/PRG/Security.game';
-import 'examples/Schemes/SymEnc/OTP.scheme';
+import '../../Primitives/PRG.primitive';
+import '../../Book/5/5_2_PseudoOTP.scheme';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Games/PRG/Security.game';
+import '../../Schemes/SymEnc/OTP.scheme';
 
 Reduction R1(OTP E, PRG G, PseudoOTP P) compose Security(G) against OneTimeUniformCiphertexts(P).Adversary {
     E.Ciphertext CTXT(E.Message m) {

--- a/Book/5_Exercises/5_8_a.proof
+++ b/Book/5_Exercises/5_8_a.proof
@@ -1,8 +1,8 @@
-import 'examples/Primitives/PRG.primitive';
-import 'examples/Games/Misc/BitStringSampling.game';
-import 'examples/Book/5_Exercises/5_8_a.scheme';
-import 'examples/Book/5_Exercises/5_8_ThreePartBitStringSampling.game';
-import 'examples/Games/PRG/Security.game';
+import '../../Primitives/PRG.primitive';
+import '../../Games/Misc/BitStringSampling.game';
+import '../../Book/5_Exercises/5_8_a.scheme';
+import '../../Book/5_Exercises/5_8_ThreePartBitStringSampling.game';
+import '../../Games/PRG/Security.game';
 
 Reduction R1(PRG G, PRG_5_8_a H) compose Security(G) against Security(H).Adversary {
     BitString<H.lambda + H.stretch> Query() {

--- a/Book/5_Exercises/5_8_a.scheme
+++ b/Book/5_Exercises/5_8_a.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRG.primitive';
+import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_8_a(PRG G) extends PRG {
     requires G.stretch == 2 * G.lambda;

--- a/Book/5_Exercises/5_8_b.proof
+++ b/Book/5_Exercises/5_8_b.proof
@@ -1,8 +1,8 @@
-import 'examples/Primitives/PRG.primitive';
-import 'examples/Games/Misc/BitStringSampling.game';
-import 'examples/Book/5_Exercises/5_8_b.scheme';
-import 'examples/Book/5_Exercises/5_8_ThreePartBitStringSampling.game';
-import 'examples/Games/PRG/Security.game';
+import '../../Primitives/PRG.primitive';
+import '../../Games/Misc/BitStringSampling.game';
+import '../../Book/5_Exercises/5_8_b.scheme';
+import '../../Book/5_Exercises/5_8_ThreePartBitStringSampling.game';
+import '../../Games/PRG/Security.game';
 
 Reduction R1(PRG G, PRG_5_8_b H) compose Security(G) against Security(H).Adversary {
     BitString<H.lambda + H.stretch> Query() {

--- a/Book/5_Exercises/5_8_b.scheme
+++ b/Book/5_Exercises/5_8_b.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRG.primitive';
+import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_8_b(PRG G) extends PRG {
     requires G.stretch == 2 * G.lambda;

--- a/Book/5_Exercises/5_8_e.proof
+++ b/Book/5_Exercises/5_8_e.proof
@@ -1,8 +1,8 @@
-import 'examples/Primitives/PRG.primitive';
-import 'examples/Book/5_Exercises/5_8_e.scheme';
-import 'examples/Book/5/5_2_PseudoOTP.scheme';
-import 'examples/Games/PRG/Security.game';
-import 'examples/Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Primitives/PRG.primitive';
+import '../../Book/5_Exercises/5_8_e.scheme';
+import '../../Book/5/5_2_PseudoOTP.scheme';
+import '../../Games/PRG/Security.game';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
 
 Reduction R1(PRG G, PRG_5_8_e H) compose Security(G) against Security(H).Adversary {
     BitString<H.lambda + H.stretch> Query() {
@@ -27,7 +27,7 @@ let:
 
 assume:
     Security(G);
-    OneTimeUniformCiphertexts(P); // see 'examples/Book/5_Exercises/5_8_PseudoOTP_OTUC.proof'
+    OneTimeUniformCiphertexts(P); // see '../../Book/5_Exercises/5_8_PseudoOTP_OTUC.proof'
 
 theorem:
     Security(H);

--- a/Book/5_Exercises/5_8_e.scheme
+++ b/Book/5_Exercises/5_8_e.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRG.primitive';
+import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_8_e(PRG G) extends PRG {
     requires G.stretch == 2 * G.lambda;

--- a/Book/5_Exercises/5_8_f.proof
+++ b/Book/5_Exercises/5_8_f.proof
@@ -1,9 +1,9 @@
-import 'examples/Primitives/PRG.primitive';
-import 'examples/Book/5_Exercises/5_8_f.scheme';
-import 'examples/Book/5/5_2_PseudoOTP.scheme';
-import 'examples/Games/Misc/BitStringSampling.game';
-import 'examples/Games/PRG/Security.game';
-import 'examples/Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Primitives/PRG.primitive';
+import '../../Book/5_Exercises/5_8_f.scheme';
+import '../../Book/5/5_2_PseudoOTP.scheme';
+import '../../Games/Misc/BitStringSampling.game';
+import '../../Games/PRG/Security.game';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
 
 Reduction R1(PRG G, PRG_5_8_f H) compose BitStringSampling(G.lambda, G.lambda) against Security(H).Adversary {
     BitString<H.lambda + H.stretch> Query() {
@@ -39,7 +39,7 @@ let:
 assume:
     Security(G);
     BitStringSampling(lambda, lambda);
-    OneTimeUniformCiphertexts(P); // see 'examples/Book/5_Exercises/5_8_PseudoOTP_OTUC.proof'
+    OneTimeUniformCiphertexts(P); // see '../../Book/5_Exercises/5_8_PseudoOTP_OTUC.proof'
 
 theorem:
     Security(H);

--- a/Book/5_Exercises/5_8_f.scheme
+++ b/Book/5_Exercises/5_8_f.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRG.primitive';
+import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_8_f(PRG G) extends PRG {
     requires G.stretch == 2 * G.lambda;

--- a/Book/7_Exercises/7_13.game
+++ b/Book/7_Exercises/7_13.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {
     E.Key k;

--- a/Book/7_Exercises/7_13_Backward.proof
+++ b/Book/7_Exercises/7_13_Backward.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Book/7_Exercises/7_13.game';
-import 'examples/Games/SymEnc/CPA.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Book/7_Exercises/7_13.game';
+import '../../Games/SymEnc/CPA.game';
 
 Reduction R1(SymEnc E) compose Challenge(E) against CPA(E).Adversary {
     E.Ciphertext Eavesdrop(E.Message mL, E.Message mR) {

--- a/Book/7_Exercises/7_13_Forward.proof
+++ b/Book/7_Exercises/7_13_Forward.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Book/7_Exercises/7_13.game';
-import 'examples/Games/SymEnc/CPA.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Book/7_Exercises/7_13.game';
+import '../../Games/SymEnc/CPA.game';
 
 Reduction R(SymEnc E) compose CPA(E) against Challenge(E).Adversary {
     E.Ciphertext Challenge(E.Message m) {

--- a/Book/9_Exercises/9_6_CCA$impliesCCA.proof
+++ b/Book/9_Exercises/9_6_CCA$impliesCCA.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Games/SymEnc/CCABook.game';
-import 'examples/Games/SymEnc/CCA$.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Games/SymEnc/CCABook.game';
+import '../../Games/SymEnc/CCA$.game';
 
 Reduction R1(SymEnc E) compose CCA$(E) against CCA(E).Adversary {
     E.Ciphertext Eavesdrop(E.Message mL, E.Message mR) {

--- a/Games/DigitalSignature/Security.game
+++ b/Games/DigitalSignature/Security.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/DigitalSignature.primitive';
+import '../../Primitives/DigitalSignature.primitive';
 
 Game Real(DigitalSignature E) {
     E.SigningKey sk;

--- a/Games/Hash/Security.game
+++ b/Games/Hash/Security.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/Hash.primitive';
+import '../../Primitives/Hash.primitive';
 
 Game Real(Hash H) {
     BitString<H.lambda> seed;

--- a/Games/KEM/CPAKEM.game
+++ b/Games/KEM/CPAKEM.game
@@ -5,7 +5,7 @@
 //  - Random: The adversary receives a real KEM ciphertext and an 
 //            independent randomly sampled shared secret
 
-import 'examples/Primitives/KEM.primitive';
+import '../../Primitives/KEM.primitive';
 
 Game Real(KEM K) {
     K.PublicKey pk;

--- a/Games/KEM/Correctness.game
+++ b/Games/KEM/Correctness.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/KEM.primitive';
+import '../../Primitives/KEM.primitive';
 
 Game Real(KEM K) {
     K.PublicKey pk;

--- a/Games/KeyAgreement/Security.game
+++ b/Games/KeyAgreement/Security.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/KeyAgreement.primitive';
+import '../../Primitives/KeyAgreement.primitive';
 
 Game Real(KeyAgreement E) {
     E.Transcript * E.Key Query() {

--- a/Games/MAC/Security.game
+++ b/Games/MAC/Security.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/MAC.primitive';
+import '../../Primitives/MAC.primitive';
 
 Game Real(MAC E) {
     E.Key k;

--- a/Games/PRF/Security.game
+++ b/Games/PRF/Security.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRF.primitive';
+import '../../Primitives/PRF.primitive';
 
 Game Real(PRF F) {
     BitString<F.lambda> k;

--- a/Games/PRG/Security.game
+++ b/Games/PRG/Security.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRG.primitive';
+import '../../Primitives/PRG.primitive';
 
 Game Real(PRG G) {
     BitString<G.lambda + G.stretch> Query() {

--- a/Games/PRP/Correctness.game
+++ b/Games/PRP/Correctness.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRP.primitive';
+import '../../Primitives/PRP.primitive';
 
 Game Real(PRP F) {
     Bool test(BitString<F.lambda> seed, BitString<F.blen> input) {

--- a/Games/PRP/Security.game
+++ b/Games/PRP/Security.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRP.primitive';
+import '../../Primitives/PRP.primitive';
 
 Game Real(PRP F) {
     BitString<F.lambda> k;

--- a/Games/PRP/StrongSecurity.game
+++ b/Games/PRP/StrongSecurity.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRP.primitive';
+import '../../Primitives/PRP.primitive';
 
 Game Real(PRP F) {
     BitString<F.lambda> k;

--- a/Games/PubKeyEnc/CPA$.game
+++ b/Games/PubKeyEnc/CPA$.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PubKeyEnc.primitive';
+import '../../Primitives/PubKeyEnc.primitive';
 
 Game Real(PubKeyEnc E) {
     E.PublicKey pk;

--- a/Games/PubKeyEnc/CPA.game
+++ b/Games/PubKeyEnc/CPA.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PubKeyEnc.primitive';
+import '../../Primitives/PubKeyEnc.primitive';
 
 Game Left(PubKeyEnc E) {
     E.PublicKey pk;

--- a/Games/PubKeyEnc/Correctness.game
+++ b/Games/PubKeyEnc/Correctness.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PubKeyEnc.primitive';
+import '../../Primitives/PubKeyEnc.primitive';
 
 Game Real(PubKeyEnc E) {
     E.PublicKey pk;

--- a/Games/PubKeyEnc/OneTimeSecrecy.game
+++ b/Games/PubKeyEnc/OneTimeSecrecy.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PubKeyEnc.primitive';
+import '../../Primitives/PubKeyEnc.primitive';
 
 Game Left(PubKeyEnc E) {
     E.PublicKey pk;

--- a/Games/SecretSharing/Correctness.game
+++ b/Games/SecretSharing/Correctness.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SecretSharing.primitive';
+import '../../Primitives/SecretSharing.primitive';
 
 Game Real(SecretSharing E) {
     Bool? Test(Set<Int> U, E.Message m) {

--- a/Games/SecretSharing/Security.game
+++ b/Games/SecretSharing/Security.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SecretSharing.primitive';
+import '../../Primitives/SecretSharing.primitive';
 
 Game Left(SecretSharing E) {
     Array<E.Share, E.shareCount>? Share(E.Message mL, E.message mR, Set<Int> U) {

--- a/Games/SymEnc/AE.game
+++ b/Games/SymEnc/AE.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {
     E.Key k;

--- a/Games/SymEnc/CCA$.game
+++ b/Games/SymEnc/CCA$.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {
     E.Key k;

--- a/Games/SymEnc/CCA.game
+++ b/Games/SymEnc/CCA.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {
     E.Key k;

--- a/Games/SymEnc/CCABook.game
+++ b/Games/SymEnc/CCABook.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {
     E.Key k;

--- a/Games/SymEnc/CPA$.game
+++ b/Games/SymEnc/CPA$.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {
     E.Key k;

--- a/Games/SymEnc/CPA.game
+++ b/Games/SymEnc/CPA.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {
     E.Key k;

--- a/Games/SymEnc/Correctness.game
+++ b/Games/SymEnc/Correctness.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {
     Bool Test(E.Key k, E.Message m) {

--- a/Games/SymEnc/KeyUniformity.game
+++ b/Games/SymEnc/KeyUniformity.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {
     E.Key Challenge() {

--- a/Games/SymEnc/OneTimeSecrecy.game
+++ b/Games/SymEnc/OneTimeSecrecy.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {
     E.Ciphertext Eavesdrop(E.Message mL, E.Message mR) {

--- a/Games/SymEnc/OneTimeUniformCiphertexts.game
+++ b/Games/SymEnc/OneTimeUniformCiphertexts.game
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {
     E.Ciphertext CTXT(E.Message m) {

--- a/Proofs/PRG/TriplingPRGSecure.proof
+++ b/Proofs/PRG/TriplingPRGSecure.proof
@@ -1,7 +1,7 @@
-import 'examples/Primitives/PRG.primitive';
-import 'examples/Schemes/PRG/TriplingPRG.scheme';
-import 'examples/Games/Misc/BitStringSampling.game';
-import 'examples/Games/PRG/Security.game';
+import '../../Primitives/PRG.primitive';
+import '../../Schemes/PRG/TriplingPRG.scheme';
+import '../../Games/Misc/BitStringSampling.game';
+import '../../Games/PRG/Security.game';
 
 Reduction R1(PRG G, TriplingPRG T) compose Security(G) against Security(T).Adversary {
     BitString<T.lambda + T.stretch> Query() {

--- a/Proofs/PubEnc/Hybrid.proof
+++ b/Proofs/PubEnc/Hybrid.proof
@@ -1,8 +1,8 @@
-import 'examples/Primitives/PubKeyEnc.primitive';
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Schemes/PubEnc/Hybrid.scheme';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
-import 'examples/Games/PubKeyEnc/CPA.game';
+import '../../Primitives/PubKeyEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
+import '../../Schemes/PubEnc/Hybrid.scheme';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
+import '../../Games/PubKeyEnc/CPA.game';
 
 Reduction R1(SymEnc E, PubKeyEnc P, Hybrid H) compose CPA(P) against CPA(H).Adversary {
     H.Ciphertext Challenge(H.Message mL, H.Message mR) {

--- a/Proofs/PubEnc/KEMDEMCPA.proof
+++ b/Proofs/PubEnc/KEMDEMCPA.proof
@@ -34,14 +34,14 @@
 // - Game 5: The hybrid scheme encrypts the right message using the *real* symmetric key.
 // - Indistinguishability of Game 4 and Game 5 based on CPA-security of the KEM.
 
-import 'examples/Primitives/KEM.primitive';
-import 'examples/Primitives/PubKeyEnc.primitive';
-import 'examples/Primitives/NonNullableSymEnc.primitive';
-import 'examples/Schemes/PubEnc/KEMDEM.scheme';
-import 'examples/Games/KEM/CPAKEM.game';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
-import 'examples/Games/SymEnc/KeyUniformity.game';
-import 'examples/Games/PubKeyEnc/CPA.game';
+import '../../Primitives/KEM.primitive';
+import '../../Primitives/PubKeyEnc.primitive';
+import '../../Primitives/NonNullableSymEnc.primitive';
+import '../../Schemes/PubEnc/KEMDEM.scheme';
+import '../../Games/KEM/CPAKEM.game';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
+import '../../Games/SymEnc/KeyUniformity.game';
+import '../../Games/PubKeyEnc/CPA.game';
 
 // Reduction for hop from Game 0 to Game 1
 // - Reduction to CPA security of the KEM. The reduction uses the shared secret

--- a/Proofs/PubEnc/OTSimpliesCPA.proof
+++ b/Proofs/PubEnc/OTSimpliesCPA.proof
@@ -1,7 +1,7 @@
-import 'examples/Primitives/PubKeyEnc.primitive';
-import 'examples/Primitives/NonNullableSymEnc.primitive';
-import 'examples/Games/PubKeyEnc/CPA.game';
-import 'examples/Games/PubKeyEnc/OneTimeSecrecy.game';
+import '../../Primitives/PubKeyEnc.primitive';
+import '../../Primitives/NonNullableSymEnc.primitive';
+import '../../Games/PubKeyEnc/CPA.game';
+import '../../Games/PubKeyEnc/OneTimeSecrecy.game';
 
 Reduction R(PubKeyEnc E, Int h) compose OneTimeSecrecy(E) against CPA(E).Adversary {
     Int count;

--- a/Proofs/SymEnc/CPA$impliesCPA.proof
+++ b/Proofs/SymEnc/CPA$impliesCPA.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Games/SymEnc/CPA.game';
-import 'examples/Games/SymEnc/CPA$.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Games/SymEnc/CPA.game';
+import '../../Games/SymEnc/CPA$.game';
 
 Reduction R1(SymEnc E) compose CPA$(E) against CPA(E).Adversary {
     E.Ciphertext Eavesdrop(E.Message mL, E.Message mR) {

--- a/Proofs/SymEnc/DoubleCPA$.proof
+++ b/Proofs/SymEnc/DoubleCPA$.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/NonNullableSymEnc.primitive';
-import 'examples/Schemes/SymEnc/GeneralDoubleSymEnc.scheme';
-import 'examples/Games/SymEnc/CPA$.game';
+import '../../Primitives/NonNullableSymEnc.primitive';
+import '../../Schemes/SymEnc/GeneralDoubleSymEnc.scheme';
+import '../../Games/SymEnc/CPA$.game';
 
 Reduction R1(SymEnc D, SymEnc E, GeneralDoubleSymEnc DSE) compose CPA$(E) against CPA$(DSE).Adversary {
     D.Key dKey;

--- a/Proofs/SymEnc/EncryptThenMACCCA.proof
+++ b/Proofs/SymEnc/EncryptThenMACCCA.proof
@@ -1,9 +1,9 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Primitives/MAC.primitive';
-import 'examples/Games/SymEnc/CPA.game';
-import 'examples/Games/MAC/Security.game';
-import 'examples/Games/SymEnc/CCABook.game';
-import 'examples/Schemes/SymEnc/EncryptThenMAC.scheme';
+import '../../Primitives/SymEnc.primitive';
+import '../../Primitives/MAC.primitive';
+import '../../Games/SymEnc/CPA.game';
+import '../../Games/MAC/Security.game';
+import '../../Games/SymEnc/CCABook.game';
+import '../../Schemes/SymEnc/EncryptThenMAC.scheme';
 
 Reduction R1(SymEnc E, MAC M, EncryptThenMAC EtM) compose Security(M) against CCA(EtM).Adversary {
     E.Key ke;

--- a/Proofs/SymEnc/GeneralDoubleOTUC.proof
+++ b/Proofs/SymEnc/GeneralDoubleOTUC.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/NonNullableSymEnc.primitive';
-import 'examples/Schemes/SymEnc/GeneralDoubleSymEnc.scheme';
-import 'examples/Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Primitives/NonNullableSymEnc.primitive';
+import '../../Schemes/SymEnc/GeneralDoubleSymEnc.scheme';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
 
 Reduction R1(GeneralDoubleSymEnc D, SymEnc S, SymEnc T) compose OneTimeUniformCiphertexts(T) against OneTimeUniformCiphertexts(D).Adversary {
     D.Ciphertext CTXT(D.Message m) {

--- a/Proofs/SymEnc/OTUCimpliesDoubleOTUC.proof
+++ b/Proofs/SymEnc/OTUCimpliesDoubleOTUC.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/NonNullableSymEnc.primitive';
-import 'examples/Schemes/SymEnc/DoubleSymEnc.scheme';
-import 'examples/Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Primitives/NonNullableSymEnc.primitive';
+import '../../Schemes/SymEnc/DoubleSymEnc.scheme';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
 
 Reduction R1(DoubleSymEnc D, SymEnc E) compose OneTimeUniformCiphertexts(E) against OneTimeUniformCiphertexts(D).Adversary {
     D.Ciphertext CTXT(D.Message m) {

--- a/Proofs/SymEnc/OTUCimpliesOTS.proof
+++ b/Proofs/SymEnc/OTUCimpliesOTS.proof
@@ -1,6 +1,6 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Games/SymEnc/OneTimeSecrecy.game';
-import 'examples/Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Primitives/SymEnc.primitive';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
 
 Reduction R1(SymEnc se) compose OneTimeUniformCiphertexts(se) against OneTimeSecrecy(se).Adversary {
     se.Ciphertext Eavesdrop(se.Message mL, se.Message mR) {

--- a/Schemes/PRG/CounterPRG.scheme
+++ b/Schemes/PRG/CounterPRG.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRF.primitive';
+import '../../Primitives/PRF.primitive';
 
 Scheme CounterPRG(PRF F) extends PRG {
     requires F.lambda == F.in;

--- a/Schemes/PRG/TriplingPRG.scheme
+++ b/Schemes/PRG/TriplingPRG.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/PRG.primitive';
+import '../../Primitives/PRG.primitive';
 
 Scheme TriplingPRG(PRG G) extends PRG {
     requires G.lambda == G.stretch;

--- a/Schemes/PubEnc/Hybrid.scheme
+++ b/Schemes/PubEnc/Hybrid.scheme
@@ -1,5 +1,5 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Primitives/PubKeyEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
+import '../../Primitives/PubKeyEnc.primitive';
 
 Scheme Hybrid(SymEnc E, PubKeyEnc P) extends PubKeyEnc {
     requires E.Key subsets P.Message;

--- a/Schemes/PubEnc/KEMDEM.scheme
+++ b/Schemes/PubEnc/KEMDEM.scheme
@@ -7,9 +7,9 @@
 // Note that this example assumes that KEM decapsulation and symmetric
 // decryption always succeed.
 
-import 'examples/Primitives/KEM.primitive';
-import 'examples/Primitives/NonNullableSymEnc.primitive';
-import 'examples/Primitives/PubKeyEnc.primitive';
+import '../../Primitives/KEM.primitive';
+import '../../Primitives/NonNullableSymEnc.primitive';
+import '../../Primitives/PubKeyEnc.primitive';
 
 Scheme KEMDEM(KEM K, SymEnc E) extends PubKeyEnc {
     requires K.SharedSecret subsets E.Key;

--- a/Schemes/SecretSharing/OTP.scheme
+++ b/Schemes/SecretSharing/OTP.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SecretSharing.primitive';
+import '../../Primitives/SecretSharing.primitive';
 
 Scheme OTP(Int l) extends SecretSharing {
     Set Message = BitString<l>;

--- a/Schemes/SymEnc/DoubleSymEnc.scheme
+++ b/Schemes/SymEnc/DoubleSymEnc.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/NonNullableSymEnc.primitive';
+import '../../Primitives/NonNullableSymEnc.primitive';
 
 Scheme DoubleSymEnc(SymEnc s) extends SymEnc {
     requires s.Message == s.Ciphertext;

--- a/Schemes/SymEnc/EncryptThenMAC.scheme
+++ b/Schemes/SymEnc/EncryptThenMAC.scheme
@@ -1,5 +1,5 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Primitives/MAC.primitive';
+import '../../Primitives/SymEnc.primitive';
+import '../../Primitives/MAC.primitive';
 
 // Specify some precondition that E.Ciphertext subsets M.Message
 Scheme EncryptThenMAC(SymEnc E, MAC M) extends SymEnc {

--- a/Schemes/SymEnc/GeneralDoubleSymEnc.scheme
+++ b/Schemes/SymEnc/GeneralDoubleSymEnc.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/NonNullableSymEnc.primitive';
+import '../../Primitives/NonNullableSymEnc.primitive';
 
 Scheme GeneralDoubleSymEnc(SymEnc S, SymEnc T) extends SymEnc {
     requires S.Ciphertext == T.Message;

--- a/Schemes/SymEnc/OFB.scheme
+++ b/Schemes/SymEnc/OFB.scheme
@@ -1,5 +1,5 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Primitives/PRF.primitive';
+import '../../Primitives/SymEnc.primitive';
+import '../../Primitives/PRF.primitive';
 
 Scheme OFB(Int lambda, Int blocks, PRF F) extends SymEnc {
     requires F.lambda == lambda && F.in == lambda && F.out == lambda;

--- a/Schemes/SymEnc/OTP.scheme
+++ b/Schemes/SymEnc/OTP.scheme
@@ -1,4 +1,4 @@
-import 'examples/Primitives/SymEnc.primitive';
+import '../../Primitives/SymEnc.primitive';
 
 Scheme OTP(Int lambda) extends SymEnc {
     Set Key = BitString<lambda>;

--- a/Schemes/SymEnc/SymEncPRF.scheme
+++ b/Schemes/SymEnc/SymEncPRF.scheme
@@ -1,5 +1,5 @@
-import 'examples/Primitives/SymEnc.primitive';
-import 'examples/Primitives/PRF.primitive';
+import '../../Primitives/SymEnc.primitive';
+import '../../Primitives/PRF.primitive';
 
 // Construction 7.4 from book
 


### PR DESCRIPTION
Import statements in FrogLang files are now resolved relative to the directory of the importing file, rather than the process's working directory. This means `proof_frog prove path/to/proof.proof` works correctly regardless of which directory the command is run from.

Key changes:
- Migrate all ~90 import strings in examples/ from repo-root-relative `'examples/X/Y'` paths to file-relative `'../../X/Y'` paths