### PR TITLE
Fix nullable type errors in OTSimpliesCPA and Hybrid reductions

### DIFF
--- a/Proofs/PubEnc/Hybrid.proof
+++ b/Proofs/PubEnc/Hybrid.proof
@@ -48,7 +48,7 @@ Reduction R2(SymEnc E, PubKeyEnc P, Hybrid H) compose OneTimeSecrecy(E) against 
     H.Ciphertext Challenge(H.Message mL, H.Message mR) {
         E.Key tkPrime = E.KeyGen();
         P.Ciphertext cpub = P.Enc(pk, tkPrime);
-        P.Ciphertext csym = challenger.Eavesdrop(mL, mR);
+        E.Ciphertext csym = challenger.Eavesdrop(mL, mR);
         return [cpub, csym];
     }
 }

--- a/Proofs/PubEnc/OTSimpliesCPA.proof
+++ b/Proofs/PubEnc/OTSimpliesCPA.proof
@@ -18,7 +18,11 @@ Reduction R(PubKeyEnc E, Int h) compose OneTimeSecrecy(E) against CPA(E).Adversa
         if (count < h) {
             return E.Enc(pk, mR);
         } else if (count == h) {
-            return challenger.Challenge(mL, mR);
+            E.Ciphertext? result = challenger.Challenge(mL, mR);
+            if (result == None) {
+                return E.Enc(pk, mL);
+            }
+            return result;
         } else {
             return E.Enc(pk, mL);
         }


### PR DESCRIPTION
OTSimpliesCPA: Reduction R's Challenge returned challenger.Challenge() directly, but OneTimeSecrecy.Challenge returns E.Ciphertext? (nullable) while CPA.Challenge requires E.Ciphertext (non-nullable).  Add null-narrowing: store the result in a nullable local, return a fallback if None, then return the narrowed value.  The fallback is unreachable under the proof's assume statements but satisfies the type checker.

Hybrid: Reduction R2 declared P.Ciphertext for the result of challenger.Eavesdrop(), but Eavesdrop returns E.Ciphertext (SymCiphertextSpace, not PubCiphertextSpace).  Fix the declared type.