### PR TITLE
Migrate product type syntax from A * B to [A, B]

### DIFF
--- a/Book/2/2_12_DoubleOTP.scheme
+++ b/Book/2/2_12_DoubleOTP.scheme
@@ -3,7 +3,7 @@ import '../../Primitives/SymEnc.primitive';
 Scheme DoubleOTP(Int lambda) extends SymEnc {
     Set Message = BitString<lambda>;
     Set Ciphertext = BitString<lambda>;
-    Set Key = BitString<lambda> * BitString<lambda>;
+    Set Key = [BitString<lambda>, BitString<lambda>];
 
     Key KeyGen() {
         BitString<lambda> key1 <- BitString<lambda>;

--- a/Book/2_Exercises/2_13_SymEncSquared.scheme
+++ b/Book/2_Exercises/2_13_SymEncSquared.scheme
@@ -2,8 +2,8 @@ import '../../Primitives/SymEnc.primitive';
 
 Scheme SymEncSquared(SymEnc E) extends SymEnc {
     Set Message = E.Message;
-    Set Ciphertext = E.Ciphertext * E.Ciphertext;
-    Set Key = E.Key * E.Key;
+    Set Ciphertext = [E.Ciphertext, E.Ciphertext];
+    Set Key = [E.Key, E.Key];
 
     Key KeyGen() {
         E.Key k1 = E.KeyGen();

--- a/Book/2_Exercises/2_15.game
+++ b/Book/2_Exercises/2_15.game
@@ -1,7 +1,7 @@
 import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {
-    E.Ciphertext * E.Ciphertext Foo(E.Message mL, E.Message mR) {
+    [E.Ciphertext, E.Ciphertext] Foo(E.Message mL, E.Message mR) {
         E.Key k1 = E.KeyGen();
         E.Ciphertext c1 = E.Enc(k1, mL);
         E.Key k2 = E.KeyGen();
@@ -11,7 +11,7 @@ Game Left(SymEnc E) {
 }
 
 Game Right(SymEnc E) {
-    E.Ciphertext * E.Ciphertext Foo(E.Message mL, E.Message mR) {
+    [E.Ciphertext, E.Ciphertext] Foo(E.Message mL, E.Message mR) {
         E.Key k1 = E.KeyGen();
         E.Ciphertext c1 = E.Enc(k1, mR);
         E.Key k2 = E.KeyGen();

--- a/Book/2_Exercises/2_15_Backward.proof
+++ b/Book/2_Exercises/2_15_Backward.proof
@@ -4,7 +4,7 @@ import '../../Games/SymEnc/OneTimeSecrecy.game';
 
 Reduction R(SymEnc E) compose Foo(E) against OneTimeSecrecy(E).Adversary {
     E.Ciphertext Eavesdrop(E.Message mL, E.Message mR) {
-        E.Ciphertext * E.Ciphertext c = challenger.Foo(mL, mR);
+        [E.Ciphertext, E.Ciphertext] c = challenger.Foo(mL, mR);
         return c[0];
     }
 }

--- a/Book/2_Exercises/2_15_Forward.proof
+++ b/Book/2_Exercises/2_15_Forward.proof
@@ -3,7 +3,7 @@ import '../../Book/2_Exercises/2_15.game';
 import '../../Games/SymEnc/OneTimeSecrecy.game';
 
 Reduction R(SymEnc E) compose OneTimeSecrecy(E) against Foo(E).Adversary {
-    E.Ciphertext * E.Ciphertext Foo(E.Message mL, E.Message mR) {
+    [E.Ciphertext, E.Ciphertext] Foo(E.Message mL, E.Message mR) {
         E.Ciphertext c1 = challenger.Eavesdrop(mL, mR);
         E.Ciphertext c2 = challenger.Eavesdrop(mR, mL);
         return [c1, c2];

--- a/Games/DigitalSignature/Security.game
+++ b/Games/DigitalSignature/Security.game
@@ -5,7 +5,7 @@ Game Real(DigitalSignature E) {
     E.VerificationKey vk;
 
     E.VerificationKey Initialize() {
-        E.SigningKey * E.VerificationKey k = E.KeyGen();
+        [E.SigningKey, E.VerificationKey] k = E.KeyGen();
         sk = k[0];
         vk = k[1];
         return k[1];
@@ -23,11 +23,11 @@ Game Real(DigitalSignature E) {
 Game Fake(DigitalSignature E) {
     E.SigningKey sk;
     E.VerificationKey vk;
-    Set<E.Message * E.Signature> S;
+    Set<[E.Message, E.Signature]> S;
 
     E.VerificationKey Initialize() {
         S = {};
-        E.SigningKey * E.VerificationKey k = E.KeyGen();
+        [E.SigningKey, E.VerificationKey] k = E.KeyGen();
         sk = k[0];
         vk = k[1];
         return k[1];

--- a/Games/KEM/CPAKEM.game
+++ b/Games/KEM/CPAKEM.game
@@ -12,14 +12,14 @@ Game Real(KEM K) {
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        K.PublicKey * K.SecretKey k = K.KeyGen();
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
     }
 
-    K.SharedSecret * K.Ciphertext Challenge() {
-        K.SharedSecret * K.Ciphertext rsp = K.Encaps(pk);
+    [K.SharedSecret, K.Ciphertext] Challenge() {
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(pk);
         K.SharedSecret ss = rsp[0];
         K.Ciphertext ctxt = rsp[1];
         return [ss, ctxt];
@@ -31,14 +31,14 @@ Game Random(KEM K) {
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        K.PublicKey * K.SecretKey k = K.KeyGen();
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
     }
 
-    K.SharedSecret * K.Ciphertext Challenge() {
-        K.SharedSecret * K.Ciphertext rsp = K.Encaps(pk);
+    [K.SharedSecret, K.Ciphertext] Challenge() {
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(pk);
         K.SharedSecret ss <- K.SharedSecret;
         K.Ciphertext ctxt = rsp[1];
         return [ss, ctxt];

--- a/Games/KEM/Correctness.game
+++ b/Games/KEM/Correctness.game
@@ -4,15 +4,15 @@ Game Real(KEM K) {
     K.PublicKey pk;
     K.SecretKey sk;
 
-    K.PublicKey * K.SecretKey Initialize() {
-        K.PublicKey * K.SecretKey k = K.KeyGen();
+    [K.PublicKey, K.SecretKey] Initialize() {
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
         pk = k[0];
         sk = k[1];
         return k;
     }
 
     Bool Test() {
-        K.SharedSecret * K.Ciphertext x = K.Encaps(pk);
+        [K.SharedSecret, K.Ciphertext] x = K.Encaps(pk);
         K.SharedSecret ss_encaps = x[0];
         K.Ciphertext ctxt = x[1];
         K.SharedSecret ss_decaps = K.Decaps(sk, ctxt);
@@ -24,8 +24,8 @@ Game Fake(KEM K) {
     K.PublicKey pk;
     K.SecretKey sk;
 
-    K.PublicKey * K.SecretKey Initialize() {
-        K.PublicKey * K.SecretKey k = K.KeyGen();
+    [K.PublicKey, K.SecretKey] Initialize() {
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
         pk = k[0];
         sk = k[1];
         return k;

--- a/Games/KeyAgreement/Security.game
+++ b/Games/KeyAgreement/Security.game
@@ -1,14 +1,14 @@
 import '../../Primitives/KeyAgreement.primitive';
 
 Game Real(KeyAgreement E) {
-    E.Transcript * E.Key Query() {
+    [E.Transcript, E.Key] Query() {
         return E.Execute();
     }
 }
 
 Game Random() {
-    E.Transcript * E.Key Query() {
-        E.Transcript * E.Key tk = E.Execute();
+    [E.Transcript, E.Key] Query() {
+        [E.Transcript, E.Key] tk = E.Execute();
         E.Key kPrime <- E.Key;
         return [tk[0], kPrime];
     }

--- a/Games/MAC/Security.game
+++ b/Games/MAC/Security.game
@@ -18,7 +18,7 @@ Game Real(MAC E) {
 
 Game Random(MAC E) {
     E.Key k;
-    Set<E.Message * E.Tag> T;
+    Set<[E.Message, E.Tag]> T;
 
     Void Initialize() {
         k = E.KeyGen();

--- a/Games/PubKeyEnc/CPA$.game
+++ b/Games/PubKeyEnc/CPA$.game
@@ -5,7 +5,7 @@ Game Real(PubKeyEnc E) {
     E.SecretKey sk;
 
     E.PublicKey Initialize() {
-        E.PublicKey * E.SecretKey k = E.KeyGen();
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
@@ -21,7 +21,7 @@ Game Random(PubKeyEnc E) {
     E.SecretKey sk;
 
     E.PublicKey Initialize() {
-        E.PublicKey * E.SecretKey k = E.KeyGen();
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;

--- a/Games/PubKeyEnc/CPA.game
+++ b/Games/PubKeyEnc/CPA.game
@@ -5,7 +5,7 @@ Game Left(PubKeyEnc E) {
     E.SecretKey sk;
 
     E.PublicKey Initialize() {
-        E.PublicKey * E.SecretKey k = E.KeyGen();
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
@@ -21,7 +21,7 @@ Game Right(PubKeyEnc E) {
     E.SecretKey sk;
 
     E.PublicKey Initialize() {
-        E.PublicKey * E.SecretKey k = E.KeyGen();
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;

--- a/Games/PubKeyEnc/Correctness.game
+++ b/Games/PubKeyEnc/Correctness.game
@@ -4,8 +4,8 @@ Game Real(PubKeyEnc E) {
     E.PublicKey pk;
     E.SecretKey sk;
 
-    E.PublicKey * E.SecretKey Initialize() {
-        E.PublicKey * E.SecretKey k = E.KeyGen();
+    [E.PublicKey, E.SecretKey] Initialize() {
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
         pk = k[0];
         sk = k[1];
         return k;
@@ -22,8 +22,8 @@ Game Fake(PubKeyEnc E) {
     E.PublicKey pk;
     E.SecretKey sk;
 
-    E.PublicKey * E.SecretKey Initialize() {
-        E.PublicKey * E.SecretKey k = E.KeyGen();
+    [E.PublicKey, E.SecretKey] Initialize() {
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
         pk = k[0];
         sk = k[1];
         return k;

--- a/Games/PubKeyEnc/OneTimeSecrecy.game
+++ b/Games/PubKeyEnc/OneTimeSecrecy.game
@@ -6,7 +6,7 @@ Game Left(PubKeyEnc E) {
     Int count;
 
     E.PublicKey Initialize() {
-        E.PublicKey * E.SecretKey k = E.KeyGen();
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
         pk = k[0];
         sk = k[1];
         count = 0;
@@ -29,7 +29,7 @@ Game Right(PubKeyEnc E) {
     Int count;
 
     E.PublicKey Initialize() {
-        E.PublicKey * E.SecretKey k = E.KeyGen();
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
         pk = k[0];
         sk = k[1];
         count = 0;

--- a/Primitives/DigitalSignature.primitive
+++ b/Primitives/DigitalSignature.primitive
@@ -4,7 +4,7 @@ Primitive DigitalSignature(Set SigningKeySpace, Set VerificationKeySpace, Set Me
     Set Message = MessageSpace;
     Set Signature = SignatureSpace;
     
-    SigningKey * VerificationKey KeyGen();
+    [SigningKey, VerificationKey] KeyGen();
     Signature Sign(SigningKey sk, Message m);
     Bool Verify(VerificationKey vk, Message m, Signature s);
 }

--- a/Primitives/KEM.primitive
+++ b/Primitives/KEM.primitive
@@ -4,7 +4,7 @@ Primitive KEM(Set SharedSecretSpace, Set CiphertextSpace, Set PKeySpace, Set SKe
     Set PublicKey = PKeySpace;
     Set SecretKey = SKeySpace;
 
-    PublicKey * SecretKey KeyGen();
-    SharedSecret * Ciphertext Encaps(PublicKey pk);
+    [PublicKey, SecretKey] KeyGen();
+    [SharedSecret, Ciphertext] Encaps(PublicKey pk);
     SharedSecret Decaps(SecretKey sk, Ciphertext m);
 }

--- a/Primitives/KeyAgreement.primitive
+++ b/Primitives/KeyAgreement.primitive
@@ -2,5 +2,5 @@ Primitive KeyAgreement(Set KeySpace, Set TranscriptSpace) {
     Set Key = KeySpace;
     Set Transcript = TranscriptSpace;
 
-    Transcript * Key Execute();
+    [Transcript, Key] Execute();
 }

--- a/Primitives/PubKeyEnc.primitive
+++ b/Primitives/PubKeyEnc.primitive
@@ -4,7 +4,7 @@ Primitive PubKeyEnc(Set MessageSpace, Set CiphertextSpace, Set PKeySpace, Set SK
     Set PublicKey = PKeySpace;
     Set SecretKey = SKeySpace;
 
-    PublicKey * SecretKey KeyGen();
+    [PublicKey, SecretKey] KeyGen();
     Ciphertext Enc(PublicKey pk, Message m);
     Message? Dec(SecretKey sk, Ciphertext m);
 }

--- a/Proofs/PubEnc/Hybrid.proof
+++ b/Proofs/PubEnc/Hybrid.proof
@@ -19,7 +19,7 @@ Game Intermediate1(SymEnc E, PubKeyEnc P, Hybrid H) {
     P.SecretKey sk;
 
     P.PublicKey Initialize() {
-        P.PublicKey * P.SecretKey k = P.KeyGen();
+        [P.PublicKey, P.SecretKey] k = P.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
@@ -39,7 +39,7 @@ Reduction R2(SymEnc E, PubKeyEnc P, Hybrid H) compose OneTimeSecrecy(E) against 
     P.SecretKey sk;
 
     P.PublicKey Initialize() {
-        P.PublicKey * P.SecretKey k = P.KeyGen();
+        [P.PublicKey, P.SecretKey] k = P.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
@@ -58,7 +58,7 @@ Game Intermediate2(SymEnc E, PubKeyEnc P, Hybrid H) {
     P.SecretKey sk;
 
     P.PublicKey Initialize() {
-        P.PublicKey * P.SecretKey k = P.KeyGen();
+        [P.PublicKey, P.SecretKey] k = P.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;

--- a/Proofs/PubEnc/KEMDEMCPA.proof
+++ b/Proofs/PubEnc/KEMDEMCPA.proof
@@ -48,7 +48,7 @@ import '../../Games/PubKeyEnc/CPA.game';
 //   from the KEM CPA challenger, which is either real (= Game 0) or random (= Game 1).
 Reduction R1(SymEnc E, KEM K, KEMDEM KD) compose CPAKEM(K) against CPA(KD).Adversary {
     KD.Ciphertext Challenge(KD.Message mL, KD.Message mR) {
-        K.SharedSecret * K.Ciphertext y = challenger.Challenge();
+        [K.SharedSecret, K.Ciphertext] y = challenger.Challenge();
         K.SharedSecret k_sym = y[0];
         K.Ciphertext c_kem = y[1];
         E.Ciphertext c_sym = E.Enc(k_sym, mL);
@@ -65,14 +65,14 @@ Reduction R2(SymEnc E, KEM K, KEMDEM KD) compose KeyUniformity(E) against CPA(KD
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        K.PublicKey * K.SecretKey k = K.KeyGen();
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
     }
 
     KD.Ciphertext Challenge(KD.Message mL, KD.Message mR) {
-        K.SharedSecret * K.Ciphertext x = K.Encaps(pk);
+        [K.SharedSecret, K.Ciphertext] x = K.Encaps(pk);
         K.SharedSecret k_sym = challenger.Challenge();
         K.Ciphertext c_kem = x[1];
         E.Ciphertext c_sym = E.Enc(k_sym, mL);
@@ -88,14 +88,14 @@ Reduction R3(SymEnc E, KEM K, KEMDEM KD) compose OneTimeSecrecy(E) against CPA(K
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        K.PublicKey * K.SecretKey k = K.KeyGen();
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
     }
 
     KD.Ciphertext Challenge(KD.Message mL, KD.Message mR) {
-        K.SharedSecret * K.Ciphertext x = K.Encaps(pk);
+        [K.SharedSecret, K.Ciphertext] x = K.Encaps(pk);
         K.Ciphertext c_kem = x[1];
         E.Ciphertext c_sym = challenger.Eavesdrop(mL, mR);
         return [c_kem, c_sym];
@@ -114,14 +114,14 @@ Reduction R4(SymEnc E, KEM K, KEMDEM KD) compose KeyUniformity(E) against CPA(KD
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        K.PublicKey * K.SecretKey k = K.KeyGen();
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
         pk = k[0];
         sk = k[1];
         return pk;
     }
 
     KD.Ciphertext Challenge(KD.Message mL, KD.Message mR) {
-        K.SharedSecret * K.Ciphertext x = K.Encaps(pk);
+        [K.SharedSecret, K.Ciphertext] x = K.Encaps(pk);
         K.SharedSecret k_sym = challenger.Challenge();
         K.Ciphertext c_kem = x[1];
         E.Ciphertext c_sym = E.Enc(k_sym, mR);
@@ -134,7 +134,7 @@ Reduction R4(SymEnc E, KEM K, KEMDEM KD) compose KeyUniformity(E) against CPA(KD
 //   from the KEM CPA challenger, which is either real (= Game 5) or random (= Game 4).
 Reduction R5(SymEnc E, KEM K, KEMDEM KD) compose CPAKEM(K) against CPA(KD).Adversary {
     KD.Ciphertext Challenge(KD.Message mL, KD.Message mR) {
-        K.SharedSecret * K.Ciphertext y = challenger.Challenge();
+        [K.SharedSecret, K.Ciphertext] y = challenger.Challenge();
         K.SharedSecret k_sym = y[0];
         K.Ciphertext c_kem = y[1];
         E.Ciphertext c_sym = E.Enc(k_sym, mR);

--- a/Proofs/SymEnc/EncryptThenMACCCA.proof
+++ b/Proofs/SymEnc/EncryptThenMACCCA.proof
@@ -7,7 +7,7 @@ import '../../Schemes/SymEnc/EncryptThenMAC.scheme';
 
 Reduction R1(SymEnc E, MAC M, EncryptThenMAC EtM) compose Security(M) against CCA(EtM).Adversary {
     E.Key ke;
-    Set<E.Ciphertext * M.Tag> S;
+    Set<[E.Ciphertext, M.Tag]> S;
     Void Initialize() {
         ke = E.KeyGen();
     }
@@ -30,7 +30,7 @@ Reduction R1(SymEnc E, MAC M, EncryptThenMAC EtM) compose Security(M) against CC
 
 Reduction R2(SymEnc E, MAC M, EncryptThenMAC EtM) compose CPA(E) against CCA(EtM).Adversary {
     M.Key km;
-    Set<E.Ciphertext * M.Tag> S;
+    Set<[E.Ciphertext, M.Tag]> S;
     Void Initialize() {
         km = M.KeyGen();
     }
@@ -52,7 +52,7 @@ Reduction R2(SymEnc E, MAC M, EncryptThenMAC EtM) compose CPA(E) against CCA(EtM
 
 Reduction R3(SymEnc E, MAC M, EncryptThenMAC EtM) compose Security(M) against CCA(EtM).Adversary {
     E.Key ke;
-    Set<E.Ciphertext * M.Tag> S;
+    Set<[E.Ciphertext, M.Tag]> S;
     Void Initialize() {
         ke = E.KeyGen();
     }

--- a/Schemes/PubEnc/Hybrid.scheme
+++ b/Schemes/PubEnc/Hybrid.scheme
@@ -5,11 +5,11 @@ Scheme Hybrid(SymEnc E, PubKeyEnc P) extends PubKeyEnc {
     requires E.Key subsets P.Message;
 
     Set Message = E.Message;
-    Set Ciphertext = P.Ciphertext * E.Ciphertext;
+    Set Ciphertext = [P.Ciphertext, E.Ciphertext];
     Set PublicKey = P.PublicKey;
     Set SecretKey = P.SecretKey;
 
-    PublicKey * SecretKey KeyGen() {
+    [PublicKey, SecretKey] KeyGen() {
         return P.KeyGen();
     }
 

--- a/Schemes/PubEnc/KEMDEM.scheme
+++ b/Schemes/PubEnc/KEMDEM.scheme
@@ -15,16 +15,16 @@ Scheme KEMDEM(KEM K, SymEnc E) extends PubKeyEnc {
     requires K.SharedSecret subsets E.Key;
 
     Set Message = E.Message;
-    Set Ciphertext = K.Ciphertext * E.Ciphertext;
+    Set Ciphertext = [K.Ciphertext, E.Ciphertext];
     Set PublicKey = K.PublicKey;
     Set SecretKey = K.SecretKey;
 
-    PublicKey * SecretKey KeyGen() {
+    [PublicKey, SecretKey] KeyGen() {
         return K.KeyGen();
     }
 
     Ciphertext Enc(PublicKey pk, Message m) {
-        K.SharedSecret * K.Ciphertext x = K.Encaps(pk);
+        [K.SharedSecret, K.Ciphertext] x = K.Encaps(pk);
         E.Key k_sym = x[0];
         K.Ciphertext c_kem = x[1];
         E.Ciphertext c_sym = E.Enc(k_sym, m);

--- a/Schemes/SymEnc/DoubleSymEnc.scheme
+++ b/Schemes/SymEnc/DoubleSymEnc.scheme
@@ -5,7 +5,7 @@ Scheme DoubleSymEnc(SymEnc s) extends SymEnc {
 
     Set Message = s.Message;
     Set Ciphertext = s.Message;
-    Set Key = s.Key * s.Key;
+    Set Key = [s.Key, s.Key];
 
     Key KeyGen() {
         s.Key key1 = s.KeyGen();

--- a/Schemes/SymEnc/EncryptThenMAC.scheme
+++ b/Schemes/SymEnc/EncryptThenMAC.scheme
@@ -5,9 +5,9 @@ import '../../Primitives/MAC.primitive';
 Scheme EncryptThenMAC(SymEnc E, MAC M) extends SymEnc {
     requires E.Ciphertext subsets M.Message;
 
-    Set Key = E.Key * M.Key;
+    Set Key = [E.Key, M.Key];
     Set Message = E.Message;
-    Set Ciphertext = E.Ciphertext * M.Tag;
+    Set Ciphertext = [E.Ciphertext, M.Tag];
 
     Key KeyGen() {
         E.Key ke = E.KeyGen();

--- a/Schemes/SymEnc/GeneralDoubleSymEnc.scheme
+++ b/Schemes/SymEnc/GeneralDoubleSymEnc.scheme
@@ -5,7 +5,7 @@ Scheme GeneralDoubleSymEnc(SymEnc S, SymEnc T) extends SymEnc {
 
     Set Message = S.Message;
     Set Ciphertext = T.Ciphertext;
-    Set Key = S.Key * T.Key;
+    Set Key = [S.Key, T.Key];
 
     Key KeyGen() {
         S.Key key1 = S.KeyGen();

--- a/Schemes/SymEnc/SymEncPRF.scheme
+++ b/Schemes/SymEnc/SymEncPRF.scheme
@@ -6,7 +6,7 @@ import '../../Primitives/PRF.primitive';
 Scheme SymEncPRF(PRF F) extends SymEnc {
     Set Key = BitString<F.lambda>;
     Set Message = BitString<F.out>;
-    Set Ciphertext = BitString<F.lambda> * BitString<F.out>;
+    Set Ciphertext = [BitString<F.lambda>, BitString<F.out>];
 
     Key KeyGen() {
         Key k <- BitString<F.lambda>;

--- a/joy/Games/SymEnc/Correctness.game
+++ b/joy/Games/SymEnc/Correctness.game
@@ -1,0 +1,22 @@
+// Claim 1.2.3: OTP Correctness
+// For all keys and messages, Dec(k, Enc(k, m)) = m.
+// The Real game encrypts then decrypts and checks equality;
+// the Ideal game always returns true.
+
+import '../../Primitives/SymEnc.primitive';
+
+Game EncDec(SymEnc E) {
+    E.Message? Test(E.Key k, E.Message m) {
+        E.Ciphertext c = E.Enc(k, m);
+        E.Message? mPrime = E.Dec(k, c);
+        return mPrime;
+    }
+}
+
+Game Identity(SymEnc E) {
+    E.Message? Test(E.Key k, E.Message m) {
+        return m;
+    }
+}
+
+export as Correctness;

--- a/joy/Games/SymEnc/OneTimeSecrecy.game
+++ b/joy/Games/SymEnc/OneTimeSecrecy.game
@@ -1,0 +1,22 @@
+// Definition 2.5.3: One-time secrecy
+// A scheme has one-time secrecy if encrypting any message produces
+// a ciphertext indistinguishable from a uniformly random ciphertext.
+
+import '../../Primitives/SymEnc.primitive';
+
+Game Real(SymEnc E) {
+    E.Ciphertext ENC(E.Message m) {
+        E.Key k = E.KeyGen();
+        E.Ciphertext c = E.Enc(k, m);
+        return c;
+    }
+}
+
+Game Random(SymEnc E) {
+    E.Ciphertext ENC(E.Message m) {
+        E.Ciphertext c <- E.Ciphertext;
+        return c;
+    }
+}
+
+export as OneTimeSecrecy;

--- a/joy/Games/SymEnc/OneTimeSecrecyLR.game
+++ b/joy/Games/SymEnc/OneTimeSecrecyLR.game
@@ -1,0 +1,23 @@
+// Definition 2.7.1: One-time secrecy (left-or-right formulation)
+// A scheme has one-time secrecy if encrypting the left plaintext
+// is indistinguishable from encrypting the right plaintext.
+
+import '../../Primitives/SymEnc.primitive';
+
+Game Left(SymEnc E) {
+    E.Ciphertext ENC(E.Message mL, E.Message mR) {
+        E.Key k = E.KeyGen();
+        E.Ciphertext c = E.Enc(k, mL);
+        return c;
+    }
+}
+
+Game Right(SymEnc E) {
+    E.Ciphertext ENC(E.Message mL, E.Message mR) {
+        E.Key k = E.KeyGen();
+        E.Ciphertext c = E.Enc(k, mR);
+        return c;
+    }
+}
+
+export as OneTimeSecrecyLR;

--- a/joy/Primitives/SymEnc.primitive
+++ b/joy/Primitives/SymEnc.primitive
@@ -1,0 +1,9 @@
+Primitive SymEnc(Set MessageSpace, Set CiphertextSpace, Set KeySpace) {
+    Set Message = MessageSpace;
+    Set Ciphertext = CiphertextSpace;
+    Set Key = KeySpace;
+
+    Key KeyGen();
+    Ciphertext Enc(Key k, Message m);
+    Message? Dec(Key k, Ciphertext c);
+}

--- a/joy/Proofs/Ch1/OTPCorrectness.proof
+++ b/joy/Proofs/Ch1/OTPCorrectness.proof
@@ -1,0 +1,23 @@
+// Claim 1.2.3: OTP Correctness
+// For all keys k and messages m, Dec(k, Enc(k, m)) = m.
+// Substituting the OTP definitions: k + (k + m) = m,
+// which holds by properties of XOR.
+
+import '../../Schemes/SymEnc/OTP.scheme';
+import '../../Games/SymEnc/Correctness.game';
+
+proof:
+
+let:
+    Int lambda;
+    OTP E = OTP(lambda);
+
+assume:
+
+theorem:
+    Correctness(E);
+
+games:
+    Correctness(E).EncDec against Correctness(E).Adversary;
+
+    Correctness(E).Identity against Correctness(E).Adversary;

--- a/joy/Proofs/Ch2/ChainedEncryptionSecure.proof
+++ b/joy/Proofs/Ch2/ChainedEncryptionSecure.proof
@@ -1,0 +1,70 @@
+// Claim 2.6.2: If E1 and E2 both have one-time secrecy,
+// then ChainedEncryption(E1, E2) has one-time secrecy.
+//
+// Proof idea: First use one-time secrecy of E1 to replace c1 with random,
+// then use one-time secrecy of E2 to replace c2 with random.
+// The engine automatically recognizes that component-wise product sampling
+// is equivalent to joint product sampling.
+
+import '../../Primitives/SymEnc.primitive';
+import '../../Schemes/SymEnc/ChainedEncryption.scheme';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
+
+// R1: delegates E1 encryption to the challenger, handles E2 encryption itself
+Reduction R1(ChainedEncryption CE, SymEnc E1, SymEnc E2) compose OneTimeSecrecy(E1) against OneTimeSecrecy(CE).Adversary {
+    CE.Ciphertext ENC(CE.Message m) {
+        E2.Key kprime = E2.KeyGen();
+        E1.Ciphertext c1 = challenger.ENC(kprime);
+        E2.Ciphertext c2 = E2.Enc(kprime, m);
+        return [c1, c2];
+    }
+}
+
+// R2: c1 is already random; delegates E2 encryption to the challenger
+Reduction R2(ChainedEncryption CE, SymEnc E1, SymEnc E2) compose OneTimeSecrecy(E2) against OneTimeSecrecy(CE).Adversary {
+    CE.Ciphertext ENC(CE.Message m) {
+        E1.Ciphertext c1 <- E1.Ciphertext;
+        E2.Ciphertext c2 = challenger.ENC(m);
+        E2.Ciphertext c2prime <- E2.Ciphertext;
+        return [c1, c2];
+    }
+}
+
+proof:
+
+let:
+    Set MessageSpace;
+    Set KeySpace1;
+    Set KeySpace2;
+    Set IntermediateSpace;
+    Set CiphertextSpace1;
+    Set CiphertextSpace2;
+
+    SymEnc E1 = SymEnc(IntermediateSpace, CiphertextSpace1, KeySpace1);
+    SymEnc E2 = SymEnc(MessageSpace, CiphertextSpace2, KeySpace2);
+    ChainedEncryption CE = ChainedEncryption(E1, E2);
+
+assume:
+    OneTimeSecrecy(E1);
+    OneTimeSecrecy(E2);
+
+theorem:
+    OneTimeSecrecy(CE);
+
+games:
+    OneTimeSecrecy(CE).Real against OneTimeSecrecy(CE).Adversary;
+
+    // Factor out E1's encryption into reduction R1
+    OneTimeSecrecy(E1).Real compose R1(CE, E1, E2) against OneTimeSecrecy(CE).Adversary;
+
+    // By assumption: E1 has one-time secrecy
+    OneTimeSecrecy(E1).Random compose R1(CE, E1, E2) against OneTimeSecrecy(CE).Adversary;
+
+    // Factor out E2's encryption into reduction R2
+    OneTimeSecrecy(E2).Real compose R2(CE, E1, E2) against OneTimeSecrecy(CE).Adversary;
+
+    // By assumption: E2 has one-time secrecy
+    OneTimeSecrecy(E2).Random compose R2(CE, E1, E2) against OneTimeSecrecy(CE).Adversary;
+
+    // Both components now random
+    OneTimeSecrecy(CE).Random against OneTimeSecrecy(CE).Adversary;

--- a/joy/Proofs/Ch2/OTPSecure.proof
+++ b/joy/Proofs/Ch2/OTPSecure.proof
@@ -1,0 +1,22 @@
+// Example 2.5.4: OTP has one-time secrecy.
+// The ciphertext k + m is uniformly distributed when k is uniform,
+// so the Real and Random games are interchangeable in one step.
+
+import '../../Schemes/SymEnc/OTP.scheme';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
+
+proof:
+
+let:
+    Int lambda;
+    OTP E = OTP(lambda);
+
+assume:
+
+theorem:
+    OneTimeSecrecy(E);
+
+games:
+    OneTimeSecrecy(E).Real against OneTimeSecrecy(E).Adversary;
+
+    OneTimeSecrecy(E).Random against OneTimeSecrecy(E).Adversary;

--- a/joy/Proofs/Ch2/OTPSecureLR.proof
+++ b/joy/Proofs/Ch2/OTPSecureLR.proof
@@ -1,0 +1,49 @@
+// OTP has one-time secrecy in the left-or-right formulation (Definition 2.7.1).
+// Follows from OTP having one-time secrecy (Definition 2.5.3):
+// real-or-random implies left-or-right.
+
+import '../../Schemes/SymEnc/OTP.scheme';
+import '../../Games/SymEnc/OneTimeSecrecyLR.game';
+import '../../Games/SymEnc/OneTimeSecrecy.game';
+
+Reduction R1(OTP E) compose OneTimeSecrecy(E) against OneTimeSecrecyLR(E).Adversary {
+    E.Ciphertext ENC(E.Message mL, E.Message mR) {
+        return challenger.ENC(mL);
+    }
+}
+
+Reduction R2(OTP E) compose OneTimeSecrecy(E) against OneTimeSecrecyLR(E).Adversary {
+    E.Ciphertext ENC(E.Message mL, E.Message mR) {
+        return challenger.ENC(mR);
+    }
+}
+
+proof:
+
+let:
+    Int lambda;
+    OTP E = OTP(lambda);
+
+assume:
+    OneTimeSecrecy(E);
+
+theorem:
+    OneTimeSecrecyLR(E);
+
+games:
+    OneTimeSecrecyLR(E).Left against OneTimeSecrecyLR(E).Adversary;
+
+    // Inline into reduction R1
+    OneTimeSecrecy(E).Real compose R1(E) against OneTimeSecrecyLR(E).Adversary;
+
+    // By assumption: one-time secrecy
+    OneTimeSecrecy(E).Random compose R1(E) against OneTimeSecrecyLR(E).Adversary;
+
+    // mL not used in Random; switch to R2
+    OneTimeSecrecy(E).Random compose R2(E) against OneTimeSecrecyLR(E).Adversary;
+
+    // By assumption (reverse direction)
+    OneTimeSecrecy(E).Real compose R2(E) against OneTimeSecrecyLR(E).Adversary;
+
+    // Inline back
+    OneTimeSecrecyLR(E).Right against OneTimeSecrecyLR(E).Adversary;

--- a/joy/README.md
+++ b/joy/README.md
@@ -1,0 +1,29 @@
+# Examples from The Joy of Cryptography (MIT Press Edition)
+
+Worked examples from [The Joy of Cryptography](https://joyofcryptography.com/) by Mike Rosulek.
+
+## Index
+
+| Book reference | Description | File |
+|---|---|---|
+| Chapter 1 | | |
+| Construction 1.2.1 | One-Time Pad | [Schemes/SymEnc/OTP.scheme](Schemes/SymEnc/OTP.scheme) |
+| Claim 1.2.3 | OTP correctness | [Games/SymEnc/Correctness.game](Games/SymEnc/Correctness.game), [Proofs/Ch1/OTPCorrectness.proof](Proofs/Ch1/OTPCorrectness.proof) |
+| Chapter 2 | | |
+| Def 2.5.1 | Symmetric-key encryption syntax | [Primitives/SymEnc.primitive](Primitives/SymEnc.primitive) |
+| Def 2.5.3 | One-time secrecy (real-or-random) | [Games/SymEnc/OneTimeSecrecy.game](Games/SymEnc/OneTimeSecrecy.game) |
+| Example 2.5.4 | OTP has one-time secrecy | [Proofs/Ch2/OTPSecure.proof](Proofs/Ch2/OTPSecure.proof) |
+| Construction 2.6.1 | Chained encryption | [Schemes/SymEnc/ChainedEncryption.scheme](Schemes/SymEnc/ChainedEncryption.scheme) |
+| Claim 2.6.2 | Chained encryption has one-time secrecy | [Proofs/Ch2/ChainedEncryptionSecure.proof](Proofs/Ch2/ChainedEncryptionSecure.proof) |
+| Exercise 2.17 | Chained encryption has correctness | [exercises/Ch2/ChainedEncryptionCorrect.proof](exercises/Ch2/ChainedEncryptionCorrect.proof) |
+| Def 2.7.1 | One-time secrecy (left-or-right) | [Games/SymEnc/OneTimeSecrecyLR.game](Games/SymEnc/OneTimeSecrecyLR.game) |
+| – | OTP has one-time secrecy (left-or-right) | [Proofs/Ch2/OTPSecureLR.proof](Proofs/Ch2/OTPSecureLR.proof) |
+| Exercise 2.21 | Encrypt-twice has one-time secrecy | [exercises/Ch2/EncryptTwice.scheme](exercises/Ch2/EncryptTwice.scheme), [exercises/Ch2/EncryptTwiceSecure.proof](exercises/Ch2/EncryptTwiceSecure.proof) |
+| Exercise 2.22 | Encrypt-halves has one-time secrecy | [exercises/Ch2/EncryptHalves.scheme](exercises/Ch2/EncryptHalves.scheme), [exercises/Ch2/EncryptHalvesSecure.proof](exercises/Ch2/EncryptHalvesSecure.proof) |
+| Exercise 2.23 | Double encryption has one-time secrecy | [exercises/Ch2/DoubleEncryption.scheme](exercises/Ch2/DoubleEncryption.scheme), [exercises/Ch2/DoubleEncryptionSecure.proof](exercises/Ch2/DoubleEncryptionSecure.proof) |
+| Exercise 2.24 | Real-or-random OTS implies left-or-right OTS | [exercises/Ch2/RORimpliesLOR.proof](exercises/Ch2/RORimpliesLOR.proof) |
+| Exercise 2.26b | Double-ciphertext scheme has left-or-right OTS | [exercises/Ch2/DoubleCiphertext.scheme](exercises/Ch2/DoubleCiphertext.scheme), [exercises/Ch2/DoubleCiphertextSecureLR.proof](exercises/Ch2/DoubleCiphertextSecureLR.proof) |
+
+### Note to Claude
+
+Within the examples/joy directory, we are creating a fresh set of examples for the new published edition of Joy of Cryptography (https://joyofcryptography.com/). You can train on examples outside of this directory, but anything you create in the examples/joy directory cannot reference any files elsewhere in the examples directory, and must use the naming and numbering conventions as in the current edition of Joy of Cryptography. Check carefully to make sure you use the conventions from the new edition, not the old. You can ask about expanding abbreviations like "rand" to "random" which might improve readability. If you are calling the MCP server, remember that the MCP server doesn't need the "examples" prefix on filenames. If you are solving exercises, put them in the joy/exercises folder (including any primitive/scheme/game files relevant only to the exercise).

--- a/joy/Schemes/SymEnc/ChainedEncryption.scheme
+++ b/joy/Schemes/SymEnc/ChainedEncryption.scheme
@@ -1,0 +1,34 @@
+// Construction 2.6.1: Chained encryption
+// Combines two encryption schemes E1, E2 by encrypting a fresh
+// key for E2 under E1, then encrypting the message under E2.
+// Requires E2's keys to be encryptable by E1.
+
+import '../../Primitives/SymEnc.primitive';
+
+Scheme ChainedEncryption(SymEnc E1, SymEnc E2) extends SymEnc {
+    requires E2.Key subsets E1.Message;
+
+    Set Key = E1.Key;
+    Set Message = E2.Message;
+    Set Ciphertext = [E1.Ciphertext, E2.Ciphertext];
+
+    Key KeyGen() {
+        E1.Key k = E1.KeyGen();
+        return k;
+    }
+
+    Ciphertext Enc(Key k, Message m) {
+        E2.Key kprime = E2.KeyGen();
+        E1.Ciphertext c1 = E1.Enc(k, kprime);
+        E2.Ciphertext c2 = E2.Enc(kprime, m);
+        return [c1, c2];
+    }
+
+    Message? Dec(Key k, Ciphertext c) {
+        E2.Key? kprime = E1.Dec(k, c[0]);
+        if (kprime == None) {
+            return None;
+        }
+        return E2.Dec(kprime, c[1]);
+    }
+}

--- a/joy/Schemes/SymEnc/OTP.scheme
+++ b/joy/Schemes/SymEnc/OTP.scheme
@@ -1,0 +1,24 @@
+// Construction 1.2.1: One-Time Pad
+// Encryption: C = K xor M
+// Decryption: M = K xor C
+
+import '../../Primitives/SymEnc.primitive';
+
+Scheme OTP(Int lambda) extends SymEnc {
+    Set Key = BitString<lambda>;
+    Set Message = BitString<lambda>;
+    Set Ciphertext = BitString<lambda>;
+
+    Key KeyGen() {
+        Key k <- Key;
+        return k;
+    }
+
+    Ciphertext Enc(Key k, Message m) {
+        return k + m;
+    }
+
+    Message Dec(Key k, Ciphertext c) {
+        return k + c;
+    }
+}


### PR DESCRIPTION
Replace binary product type notation with n-ary bracket syntax across all primitive, scheme, game, and proof files.