### PR TITLE
Add RandomFunctions and <-uniq support to PRF examples

### DIFF
--- a/Games/Misc/Sample.game
+++ b/Games/Misc/Sample.game
@@ -9,8 +9,7 @@ Game NoReplacement(Int lambda) {
     Set<BitString<lambda>> R;
 
     BitString<lambda> Samp() {
-        BitString<lambda> r <- BitString<lambda> \ R;
-        R = R union {r};
+        BitString<lambda> r <-uniq[R] BitString<lambda>;
         return r;
     }
 }

--- a/Games/PRF/Security.game
+++ b/Games/PRF/Security.game
@@ -12,16 +12,14 @@ Game Real(PRF F) {
 }
 
 Game Random(PRF F) {
-    Map<BitString<F.in>, BitString<F.out>> T;
+    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
+        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
     }
 
     BitString<F.out> Lookup(BitString<F.in> x) {
-        if (!(x in T)) {
-            T[x] <- BitString<F.out>;
-        }
-        return T[x];
+        return RF(x);
     }
 }
 

--- a/Proofs/SymEnc/SymEncPRFSimpleOTUC.proof
+++ b/Proofs/SymEnc/SymEncPRFSimpleOTUC.proof
@@ -1,0 +1,153 @@
+import '../../Primitives/PRF.primitive';
+import '../../Primitives/SymEnc.primitive';
+import '../../Schemes/SymEnc/SymEncPRFSimple.scheme';
+import '../../Games/SymEnc/OneTimeUniformCiphertexts.game';
+import '../../Games/PRF/Security.game' as PRFSecurity;
+import '../../Games/Misc/Sample.game';
+
+// Main result: SymEncPRFSimple satisfies OneTimeUniformCiphertexts
+// assuming PRF security and the birthday-bound sampling assumption.
+//
+// Proof structure:
+//   OTUC.Real
+//   -> G0            move key to Initialize
+//   -> PRF.Real o R_PRF   interchangeability
+//   -> PRF.Random o R_PRF   by PRF assumption
+//   -> G_RF            interchangeability
+//   -> Sample.Repl o R_Sample  interchangeability
+//   -> Sample.NoRepl o R_Sample  by Sample assumption (birthday bound, forward)
+//   -> G_Uniq          interchangeability
+//   -> Sample.NoRepl o R_Sample2  interchangeability (engine: RF(r)->uniform)
+//   -> Sample.Repl o R_Sample2  by Sample assumption (birthday bound, reverse)
+//   -> OTUC.Random        interchangeability
+
+// G0: OTUC.Real with key as a field instead of local variable
+Game G0(SymEnc E, PRF F) {
+    BitString<F.lambda> k;
+
+    Void Initialize() {
+        k <- BitString<F.lambda>;
+    }
+
+    E.Ciphertext CTXT(E.Message m) {
+        BitString<F.in> r <- BitString<F.in>;
+        BitString<F.out> z = F.evaluate(k, r);
+        return [r, m + z];
+    }
+}
+
+// Reduction for the PRF hop
+Reduction R_PRF(SymEnc E, PRF F) compose PRFSecurity(F) against OneTimeUniformCiphertexts(E).Adversary {
+    E.Ciphertext CTXT(E.Message m) {
+        BitString<F.in> r <- BitString<F.in>;
+        BitString<F.out> z = challenger.Lookup(r);
+        return [r, m + z];
+    }
+}
+
+// Intermediate game: PRF replaced by random function
+Game G_RF(SymEnc E, PRF F) {
+    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+
+    Void Initialize() {
+        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+    }
+
+    E.Ciphertext CTXT(E.Message m) {
+        BitString<F.in> r <- BitString<F.in>;
+        BitString<F.out> z = RF(r);
+        return [r, m + z];
+    }
+}
+
+// Reduction for forward Sample hop (Replacement -> NoReplacement on r)
+Reduction R_Sample(SymEnc E, PRF F) compose Sample(F.in) against OneTimeUniformCiphertexts(E).Adversary {
+    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+
+    Void Initialize() {
+        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+    }
+
+    E.Ciphertext CTXT(E.Message m) {
+        BitString<F.in> r = challenger.Samp();
+        BitString<F.out> z = RF(r);
+        return [r, m + z];
+    }
+}
+
+// Intermediate game: unique sampling with RF
+Game G_Uniq(SymEnc E, PRF F) {
+    Set<BitString<F.in>> R;
+    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+
+    Void Initialize() {
+        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+    }
+
+    E.Ciphertext CTXT(E.Message m) {
+        BitString<F.in> r <-uniq[R] BitString<F.in>;
+        BitString<F.out> z = RF(r);
+        return [r, m + z];
+    }
+}
+
+// Reduction for reverse Sample hop (NoReplacement -> Replacement on r)
+// After UniqueRFSimplification, z = RF(r) becomes z <- uniform,
+// so this reduction just samples z uniformly and delegates r to challenger
+Reduction R_Sample2(SymEnc E, PRF F) compose Sample(F.in) against OneTimeUniformCiphertexts(E).Adversary {
+    E.Ciphertext CTXT(E.Message m) {
+        BitString<F.in> r = challenger.Samp();
+        BitString<F.out> z <- BitString<F.out>;
+        return [r, m + z];
+    }
+}
+
+proof:
+
+let:
+    Int lambda;
+    Int in;
+    Int out;
+    PRF F = PRF(lambda, in, out);
+    SymEnc E = SymEncPRFSimple(F);
+
+assume:
+    PRFSecurity(F);
+    Sample(F.in);
+
+theorem:
+    OneTimeUniformCiphertexts(E);
+
+games:
+    // OTUC.Real composed with SymEncPRFSimple
+    OneTimeUniformCiphertexts(E).Real against OneTimeUniformCiphertexts(E).Adversary;
+
+    // Move key sampling to Initialize
+    G0(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // Interchangeability with PRF.Real compose R_PRF
+    PRFSecurity(F).Real compose R_PRF(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // By PRF assumption
+    PRFSecurity(F).Random compose R_PRF(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // Interchangeability
+    G_RF(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // Interchangeability
+    Sample(F.in).Replacement compose R_Sample(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // By Sample assumption (forward: Replacement -> NoReplacement)
+    Sample(F.in).NoReplacement compose R_Sample(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // Interchangeability
+    G_Uniq(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // Interchangeability (engine: UniqueRF simplification, RF(r) -> z <- R)
+    Sample(F.in).NoReplacement compose R_Sample2(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // By Sample assumption (reverse: NoReplacement -> Replacement)
+    Sample(F.in).Replacement compose R_Sample2(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+
+    // Interchangeability: uniform r, uniform z, m + z -> uniform = OTUC.Random
+    OneTimeUniformCiphertexts(E).Random against OneTimeUniformCiphertexts(E).Adversary;

--- a/Schemes/SymEnc/SymEncPRFSimple.scheme
+++ b/Schemes/SymEnc/SymEncPRFSimple.scheme
@@ -1,0 +1,27 @@
+import '../../Primitives/SymEnc.primitive';
+import '../../Primitives/PRF.primitive';
+
+// PRF-based encryption: c = (r, m XOR PRF(k, r))
+// Simpler than SymEncPRF because it does not require F.in == F.lambda
+
+Scheme SymEncPRFSimple(PRF F) extends SymEnc {
+    Set Key = BitString<F.lambda>;
+    Set Message = BitString<F.out>;
+    Set Ciphertext = [BitString<F.in>, BitString<F.out>];
+
+    Key KeyGen() {
+        Key k <- BitString<F.lambda>;
+        return k;
+    }
+
+    Ciphertext Enc(Key k, Message m) {
+        BitString<F.in> r <- BitString<F.in>;
+        BitString<F.out> z = F.evaluate(k, r);
+        return [r, m + z];
+    }
+
+    Message Dec(Key k, Ciphertext c) {
+        Message m = F.evaluate(k, c[0]) + c[1];
+        return m;
+    }
+}


### PR DESCRIPTION
- PRF/Security.game: Random game uses RandomFunctions<D, R> instead of Map-based lazy sampling
- Misc/Sample.game: NoReplacement game uses <-uniq[R] instead of set-difference and union
- New SymEncPRFSimple scheme: c = (r, m XOR PRF(k, r))
- New SymEncPRFSimpleOTUC proof: OTUC for SymEncPRFSimple via PRF and Sample assumptions (9/10 steps verified)