### PR TITLE
Add KEMPRF IND-CCA security proof and CCAKEM game

### DIFF
--- a/Games/KEM/CCAKEM.game
+++ b/Games/KEM/CCAKEM.game
@@ -1,0 +1,51 @@
+// CCA security for a KEM is defined as indistinguishability between
+// two games:
+//  - Real:   The adversary receives a real shared secret from encapsulation
+//  - Random: The adversary receives a random shared secret
+// Both games provide a Decaps oracle that decapsulates any ciphertext
+// except the challenge ciphertext.
+
+import '../../Primitives/KEM.primitive';
+
+Game Real(KEM K) {
+    K.SecretKey sk;
+    K.Ciphertext ctStar;
+
+    [K.PublicKey, K.SharedSecret, K.Ciphertext] Initialize() {
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
+        sk = k[1];
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        ctStar = rsp[1];
+        return [k[0], rsp[0], rsp[1]];
+    }
+
+    K.SharedSecret? Decaps(K.Ciphertext c) {
+        if (c == ctStar) {
+            return None;
+        }
+        return K.Decaps(sk, c);
+    }
+}
+
+Game Random(KEM K) {
+    K.SecretKey sk;
+    K.Ciphertext ctStar;
+
+    [K.PublicKey, K.SharedSecret, K.Ciphertext] Initialize() {
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
+        sk = k[1];
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        K.SharedSecret ss <- K.SharedSecret;
+        ctStar = rsp[1];
+        return [k[0], ss, rsp[1]];
+    }
+
+    K.SharedSecret? Decaps(K.Ciphertext c) {
+        if (c == ctStar) {
+            return None;
+        }
+        return K.Decaps(sk, c);
+    }
+}
+
+export as CCAKEM;

--- a/Proofs/KEM/KEMPRFCCA.proof
+++ b/Proofs/KEM/KEMPRFCCA.proof
@@ -1,0 +1,114 @@
+// Proof that KEMPRF satisfies CCA security for KEMs,
+// assuming the underlying KEM is CCA-secure and the PRF has multi-key security.
+//
+// Main idea:
+// 1. Replace real KEM shared secret k* with random k* (KEM CCA assumption)
+// 2. Replace PRF(random_key, ct) with uniform random (multi-key PRF assumption)
+
+import '../../Primitives/KEM.primitive';
+import '../../Primitives/PRF.primitive';
+import '../../Schemes/KEM/KEMPRF.scheme';
+import '../../Games/KEM/CCAKEM.game';
+import '../../Games/PRF/MultiKey.game';
+
+// Reduction for KEM CCA hop: receives (pk, ss, ct) from KEM challenger,
+// applies F.evaluate(ss, ct) to produce the KEMPRF shared secret.
+Reduction R_KEM(KEM K, PRF F, KEMPRF KF) compose CCAKEM(K) against CCAKEM(KF).Adversary {
+    KF.Ciphertext ctStar;
+
+    [KF.PublicKey, KF.SharedSecret, KF.Ciphertext] Initialize() {
+        [K.PublicKey, K.SharedSecret, K.Ciphertext] rsp = challenger.Initialize();
+        K.SharedSecret ss = rsp[1];
+        K.Ciphertext ct = rsp[2];
+        ctStar = ct;
+        return [rsp[0], F.evaluate(ss, ct), ct];
+    }
+
+    KF.SharedSecret? Decaps(KF.Ciphertext c) {
+        if (c == ctStar) {
+            return None;
+        }
+        K.SharedSecret? k = challenger.Decaps(c);
+        if (k == None) {
+            return None;
+        }
+        return F.evaluate(k, c);
+    }
+}
+
+// Intermediate game: PRF with a random key applied to KEM ciphertext,
+// with a Decaps oracle
+Game G_RandKey(KEM K, PRF F) {
+    K.SecretKey sk;
+    K.Ciphertext ctStar;
+
+    [K.PublicKey, BitString<F.out>, K.Ciphertext] Initialize() {
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
+        sk = k[1];
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        BitString<F.lambda> key <- BitString<F.lambda>;
+        ctStar = rsp[1];
+        return [k[0], F.evaluate(key, rsp[1]), rsp[1]];
+    }
+
+    BitString<F.out>? Decaps(K.Ciphertext c) {
+        if (c == ctStar) {
+            return None;
+        }
+        K.SharedSecret k = K.Decaps(sk, c);
+        return F.evaluate(k, c);
+    }
+}
+
+// Reduction for multi-key PRF hop
+Reduction R_MultiPRF(KEM K, PRF F, KEMPRF KF) compose MultiKeyPRFSecurity(F) against CCAKEM(KF).Adversary {
+    K.SecretKey sk;
+    K.Ciphertext ctStar;
+
+    [KF.PublicKey, KF.SharedSecret, KF.Ciphertext] Initialize() {
+        [K.PublicKey, K.SecretKey] k = K.KeyGen();
+        sk = k[1];
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        ctStar = rsp[1];
+        BitString<F.out> ss = challenger.Lookup(rsp[1]);
+        return [k[0], ss, rsp[1]];
+    }
+
+    KF.SharedSecret? Decaps(KF.Ciphertext c) {
+        if (c == ctStar) {
+            return None;
+        }
+        K.SharedSecret k = K.Decaps(sk, c);
+        return F.evaluate(k, c);
+    }
+}
+
+proof:
+
+let:
+    Int lambda;
+    Int in;
+    Int out;
+    Set SharedSecretSpace;
+    Set CiphertextSpace;
+    Set PKeySpace;
+    Set SKeySpace;
+    KEM K = KEM(SharedSecretSpace, CiphertextSpace, PKeySpace, SKeySpace);
+    PRF F = PRF(lambda, in, out);
+    KEMPRF KF = KEMPRF(K, F);
+
+assume:
+    CCAKEM(K);
+    MultiKeyPRFSecurity(F);
+
+theorem:
+    CCAKEM(KF);
+
+games:
+    CCAKEM(KF).Real against CCAKEM(KF).Adversary;
+    CCAKEM(K).Real compose R_KEM(K, F, KF) against CCAKEM(KF).Adversary;
+    CCAKEM(K).Random compose R_KEM(K, F, KF) against CCAKEM(KF).Adversary;
+    G_RandKey(K, F) against CCAKEM(KF).Adversary;
+    MultiKeyPRFSecurity(F).Real compose R_MultiPRF(K, F, KF) against CCAKEM(KF).Adversary;
+    MultiKeyPRFSecurity(F).Random compose R_MultiPRF(K, F, KF) against CCAKEM(KF).Adversary;
+    CCAKEM(KF).Random against CCAKEM(KF).Adversary;


### PR DESCRIPTION
- CCAKEM.game: IND-CCA security game for KEMs with Decaps oracle
- KEMPRFCCA.proof: prove KEMPRF satisfies IND-CCA security assuming CCA security of the underlying KEM and multi-key PRF security