### PR TITLE
Add deterministic and injective annotations to primitive method declarations

### DIFF
--- a/Primitives/DigitalSignature.primitive
+++ b/Primitives/DigitalSignature.primitive
@@ -6,5 +6,5 @@ Primitive DigitalSignature(Set SigningKeySpace, Set VerificationKeySpace, Set Me
     
     [SigningKey, VerificationKey] KeyGen();
     Signature Sign(SigningKey sk, Message m);
-    Bool Verify(VerificationKey vk, Message m, Signature s);
+    deterministic Bool Verify(VerificationKey vk, Message m, Signature s);
 }

--- a/Primitives/Hash.primitive
+++ b/Primitives/Hash.primitive
@@ -2,5 +2,5 @@ Primitive Hash(Int lambda, Int outputLen) {
     Int lambda = lambda;
     Int outputLen = outputLen;
 
-    BitString<outputLen> evaluate(BitString<lambda> seed, BitString input);
+    deterministic BitString<outputLen> evaluate(BitString<lambda> seed, BitString input);
 }

--- a/Primitives/KEM.primitive
+++ b/Primitives/KEM.primitive
@@ -6,5 +6,5 @@ Primitive KEM(Set SharedSecretSpace, Set CiphertextSpace, Set PKeySpace, Set SKe
 
     [PublicKey, SecretKey] KeyGen();
     [SharedSecret, Ciphertext] Encaps(PublicKey pk);
-    SharedSecret Decaps(SecretKey sk, Ciphertext m);
+    deterministic SharedSecret Decaps(SecretKey sk, Ciphertext m);
 }

--- a/Primitives/MAC.primitive
+++ b/Primitives/MAC.primitive
@@ -5,5 +5,5 @@ Primitive MAC(Set MessageSpace, Set TagSpace, Set KeySpace) {
 
     Key KeyGen();
 
-    Tag MAC(Key k, Message m);
+    deterministic Tag MAC(Key k, Message m);
 }

--- a/Primitives/NonNullableSymEnc.primitive
+++ b/Primitives/NonNullableSymEnc.primitive
@@ -5,5 +5,5 @@ Primitive SymEnc(Set MessageSpace, Set CiphertextSpace, Set KeySpace) {
 
     Key KeyGen();
     Ciphertext Enc(Key k, Message m);
-    Message Dec(Key k, Ciphertext c);
+    deterministic Message Dec(Key k, Ciphertext c);
 }

--- a/Primitives/PRF.primitive
+++ b/Primitives/PRF.primitive
@@ -3,5 +3,5 @@ Primitive PRF(Int lambda, Int in, Int out) {
     Int in = in;
     Int out = out;
 
-    BitString<out> evaluate(BitString<lambda> seed, BitString<in> input);
+    deterministic BitString<out> evaluate(BitString<lambda> seed, BitString<in> input);
 }

--- a/Primitives/PRG.primitive
+++ b/Primitives/PRG.primitive
@@ -2,5 +2,5 @@ Primitive PRG(Int lambda, Int stretch) {
     Int lambda = lambda;
     Int stretch = stretch;
 
-    BitString<lambda + stretch> evaluate(BitString<lambda> x);
+    deterministic BitString<lambda + stretch> evaluate(BitString<lambda> x);
 }

--- a/Primitives/PRP.primitive
+++ b/Primitives/PRP.primitive
@@ -2,7 +2,7 @@ Primitive PRP(Int lambda, Int blen) {
     Int lambda = lambda;
     Int blen = blen;
 
-    BitString<blen> evaluate(BitString<lambda> seed, BitString<blen> input);
+    deterministic injective BitString<blen> evaluate(BitString<lambda> seed, BitString<blen> input);
 
-    BitString<blen> evaluateInverse(BitString<lambda> seed, BitString<blen> input);
+    deterministic injective BitString<blen> evaluateInverse(BitString<lambda> seed, BitString<blen> input);
 }

--- a/Primitives/PubKeyEnc.primitive
+++ b/Primitives/PubKeyEnc.primitive
@@ -6,5 +6,5 @@ Primitive PubKeyEnc(Set MessageSpace, Set CiphertextSpace, Set PKeySpace, Set SK
 
     [PublicKey, SecretKey] KeyGen();
     Ciphertext Enc(PublicKey pk, Message m);
-    Message? Dec(SecretKey sk, Ciphertext m);
+    deterministic Message? Dec(SecretKey sk, Ciphertext m);
 }

--- a/Primitives/SecretSharing.primitive
+++ b/Primitives/SecretSharing.primitive
@@ -6,5 +6,5 @@ Primitive SecretSharing(Set MessageSpace, Set ShareSpace, Int n, Int t) {
 
     Array<Share, shareCount> Share(Message m);
 
-    Message? Reconstruct(Array<Share, shareCount> s);
+    deterministic Message? Reconstruct(Array<Share, shareCount> s);
 }

--- a/Primitives/SymEnc.primitive
+++ b/Primitives/SymEnc.primitive
@@ -5,5 +5,5 @@ Primitive SymEnc(Set MessageSpace, Set CiphertextSpace, Set KeySpace) {
 
     Key KeyGen();
     Ciphertext Enc(Key k, Message m);
-    Message? Dec(Key k, Ciphertext c);
+    deterministic Message? Dec(Key k, Ciphertext c);
 }

--- a/applications/KEMCombiner-GHP18/TwoKeyPRF.primitive
+++ b/applications/KEMCombiner-GHP18/TwoKeyPRF.primitive
@@ -4,5 +4,5 @@ Primitive TwoKeyPRF(Int lambda1, Int lambda2, Int in, Int out) {
     Int in = in;
     Int out = out;
 
-    BitString<out> evaluate(BitString<lambda1> key1, BitString<lambda2> key2, BitString<in> input);
+    deterministic BitString<out> evaluate(BitString<lambda1> key1, BitString<lambda2> key2, BitString<in> input);
 }

--- a/joy/Primitives/SymEnc.primitive
+++ b/joy/Primitives/SymEnc.primitive
@@ -5,5 +5,5 @@ Primitive SymEnc(Set MessageSpace, Set CiphertextSpace, Set KeySpace) {
 
     Key KeyGen();
     Ciphertext Enc(Key k, Message m);
-    Message? Dec(Key k, Ciphertext c);
+    deterministic Message? Dec(Key k, Ciphertext c);
 }


### PR DESCRIPTION
Annotate methods across all primitive definitions with `deterministic` and/or `injective` modifiers to declare their semantic contracts:

- `deterministic` on methods that always return the same output for the same inputs: Decaps, evaluate, Dec, Verify, Reconstruct, Exp, Generator, DeriveKeyPair, DeriveExponent, MAC
- `injective` on methods that map distinct inputs to distinct outputs: PRP.evaluate/evaluateInverse, and all Encode methods
- Methods using randomness (KeyGen, Encaps, Sign, SampleExponent, Share) are left unannotated