### PR TITLE
Strengthen SharedSecret requires from subsets to == in KEMPRF and KEMCombiner

### DIFF
--- a/Schemes/KEM/KEMPRF.scheme
+++ b/Schemes/KEM/KEMPRF.scheme
@@ -2,7 +2,7 @@ import '../../Primitives/KEM.primitive';
 import '../../Primitives/PRF.primitive';
 
 Scheme KEMPRF(KEM K, PRF F) extends KEM {
-    requires K.SharedSecret subsets BitString<F.lambda>;
+    requires K.SharedSecret == BitString<F.lambda>;
     requires K.Ciphertext subsets BitString<F.in>;
 
     Set Ciphertext = K.Ciphertext;

--- a/applications/KEMCombiner-GHP18/KEMCombiner.scheme
+++ b/applications/KEMCombiner-GHP18/KEMCombiner.scheme
@@ -7,8 +7,8 @@ import '../../Primitives/KEM.primitive';
 import 'TwoKeyPRF.primitive';
 
 Scheme KEMCombiner(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk2len, Int ct2len) extends KEM {
-    requires KEM1.SharedSecret subsets BitString<F.lambda1>;
-    requires KEM2.SharedSecret subsets BitString<F.lambda2>;
+    requires KEM1.SharedSecret == BitString<F.lambda1>;
+    requires KEM2.SharedSecret == BitString<F.lambda2>;
     requires KEM1.PublicKey subsets BitString<pk1len>;
     requires KEM1.Ciphertext subsets BitString<ct1len>;
     requires KEM2.PublicKey subsets BitString<pk2len>;


### PR DESCRIPTION
The proofs for these schemes depend on sampling normalization between the KEM's SharedSecret type and the PRF's key space. The `subsets` constraint allows proper subsets (|A| < |B|), which would make replacing `x <- A` with `x <- B` unsound. The `==` constraint guarantees equal cardinality, which is what the proofs actually require. Other `subsets` constraints (Ciphertext, PublicKey, etc.) are left unchanged as no proof depends on normalizing their sampling.