### PR TITLE
Add ElGamal scheme, DDH game, and ElGamal proofs (#27)

### DIFF
--- a/Games/Group/DDH.game
+++ b/Games/Group/DDH.game
@@ -1,0 +1,35 @@
+// Decisional Diffie-Hellman assumption using built-in GroupElem type.
+// Left: (pk, g^r, pk^r)  Right: (pk, g^r, random)
+
+Game Left(Group G) {
+    GroupElem<G> pk;
+
+    GroupElem<G> Initialize() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        pk = G.generator ^ a;
+        return pk;
+    }
+
+    [GroupElem<G>, GroupElem<G>] Challenge() {
+        ModInt<G.order> r <- ModInt<G.order>;
+        return [G.generator ^ r, pk ^ r];
+    }
+}
+
+Game Right(Group G) {
+    GroupElem<G> pk;
+
+    GroupElem<G> Initialize() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        pk = G.generator ^ a;
+        return pk;
+    }
+
+    [GroupElem<G>, GroupElem<G>] Challenge() {
+        ModInt<G.order> r <- ModInt<G.order>;
+        GroupElem<G> c <- GroupElem<G>;
+        return [G.generator ^ r, c];
+    }
+}
+
+export as DDH;

--- a/Proofs/PubEnc/ElGamalCPA.proof
+++ b/Proofs/PubEnc/ElGamalCPA.proof
@@ -1,0 +1,69 @@
+// Main result: ElGamal encryption is IND-CPA secure under DDH.
+// Uses built-in GroupElem type -- no helper assumptions needed.
+//
+// High-level proof idea:
+// DDH replaces the DH shared secret pk^r with a random group element c.
+// The engine's uniform GroupElem masking transform then simplifies
+// mL * c (or mR * c) to just c, making the ciphertext independent
+// of the message.
+//
+// Game sequence:
+//   CPA.Left               -- [g^r, mL * pk^r]
+//   DDH.Left  o R_L        -- same by interchangeability
+//   DDH.Right o R_L        -- by DDH: pk^r -> random c; then mL*c -> c
+//   DDH.Right o R_R        -- same (both canonicalize to [g^r, c])
+//   DDH.Left  o R_R        -- by DDH (reverse)
+//   CPA.Right              -- [g^r, mR * pk^r]
+
+import '../../Primitives/PubKeyEnc.primitive';
+import '../../Games/PubKeyEnc/CPA.game';
+import '../../Games/Group/DDH.game';
+import '../../Schemes/PubEnc/ElGamal.scheme';
+
+// DDH reduction (left message): multiplies mL into the DDH value.
+Reduction R_L(Group G) compose DDH(G) against CPA(ElGamal(G)).Adversary {
+    GroupElem<G> Initialize(GroupElem<G> pk) {
+        return pk;
+    }
+
+    [GroupElem<G>, GroupElem<G>] Challenge(GroupElem<G> mL, GroupElem<G> mR) {
+        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
+        return [pair[0], mL * pair[1]];
+    }
+}
+
+// DDH reduction (right message): multiplies mR into the DDH value.
+Reduction R_R(Group G) compose DDH(G) against CPA(ElGamal(G)).Adversary {
+    GroupElem<G> Initialize(GroupElem<G> pk) {
+        return pk;
+    }
+
+    [GroupElem<G>, GroupElem<G>] Challenge(GroupElem<G> mL, GroupElem<G> mR) {
+        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
+        return [pair[0], mR * pair[1]];
+    }
+}
+
+proof:
+
+let:
+    Group G;
+    PubKeyEnc E = ElGamal(G);
+
+assume:
+    DDH(G);
+
+theorem:
+    CPA(E);
+
+games:
+    CPA(E).Left against CPA(E).Adversary;
+
+    DDH(G).Left compose R_L(G) against CPA(E).Adversary;
+    DDH(G).Right compose R_L(G) against CPA(E).Adversary;
+
+    DDH(G).Right compose R_R(G) against CPA(E).Adversary;
+
+    DDH(G).Left compose R_R(G) against CPA(E).Adversary;
+
+    CPA(E).Right against CPA(E).Adversary;

--- a/Proofs/PubEnc/ElGamalCorrectness.proof
+++ b/Proofs/PubEnc/ElGamalCorrectness.proof
@@ -1,0 +1,27 @@
+// ElGamal Correctness
+// Dec(sk, Enc(pk, m)) = m for all messages m.
+// Substituting ElGamal definitions:
+//   Enc(pk, m) = [g^r, m * pk^r]
+//   Dec(sk, [g^r, m * pk^r]) = (m * pk^r) / (g^r)^sk
+//                             = (m * (g^a)^r) / (g^(r*a))
+//                             = m
+// which holds by properties of group exponentiation.
+
+import '../../Schemes/PubEnc/ElGamal.scheme';
+import '../../Games/PubKeyEnc/Correctness.game';
+
+proof:
+
+let:
+    Group G;
+    ElGamal E = ElGamal(G);
+
+assume:
+
+theorem:
+    Correctness(E);
+
+games:
+    Correctness(E).Real against Correctness(E).Adversary;
+
+    Correctness(E).Fake against Correctness(E).Adversary;

--- a/Schemes/PubEnc/ElGamal.scheme
+++ b/Schemes/PubEnc/ElGamal.scheme
@@ -1,0 +1,22 @@
+import '../../Primitives/PubKeyEnc.primitive';
+
+Scheme ElGamal(Group G) extends PubKeyEnc {
+    Set Message = GroupElem<G>;
+    Set Ciphertext = [GroupElem<G>, GroupElem<G>];
+    Set PublicKey = GroupElem<G>;
+    Set SecretKey = ModInt<G.order>;
+
+    [PublicKey, SecretKey] KeyGen() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        return [G.generator ^ a, a];
+    }
+
+    Ciphertext Enc(PublicKey pk, Message m) {
+        ModInt<G.order> r <- ModInt<G.order>;
+        return [G.generator ^ r, m * pk ^ r];
+    }
+
+    Message? Dec(SecretKey sk, Ciphertext c) {
+        return c[1] / c[0] ^ sk;
+    }
+}


### PR DESCRIPTION
Add ElGamal encryption using the built-in Group type, the DDH security game, and proofs of ElGamal CPA security and correctness.

New files:
- Schemes/PubEnc/ElGamal.scheme: ElGamal encryption over GroupElem<G>
- Games/Group/DDH.game: Decisional Diffie-Hellman assumption
- Proofs/PubEnc/ElGamalCPA.proof: IND-CPA security under DDH
- Proofs/PubEnc/ElGamalCorrectness.proof: Dec(sk, Enc(pk, m)) = m