### PR TITLE
Add Hashed ElGamal proofs and rename RandomFunctions to Function

### DIFF
--- a/Games/Group/HashedDDH.game
+++ b/Games/Group/HashedDDH.game
@@ -1,0 +1,48 @@
+// Hashed Decisional Diffie-Hellman assumption.
+// Left:  (pk, g^r, H(pk^r))   -- hash of real DH shared secret
+// Right: (pk, g^r, random)     -- independent random bitstring
+//
+// Includes a Hash oracle so the same game works for both standard model
+// and ROM. In the standard model, giving the adversary an oracle for a
+// function it can already compute does not change security.
+
+Game Left(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) {
+    GroupElem<G> pk;
+
+    GroupElem<G> Initialize() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        pk = G.generator ^ a;
+        return pk;
+    }
+
+    BitString<n> Hash(GroupElem<G> x) {
+        return H(x);
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge() {
+        ModInt<G.order> r <- ModInt<G.order>;
+        return [G.generator ^ r, H(pk ^ r)];
+    }
+}
+
+Game Right(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) {
+    GroupElem<G> pk;
+
+    GroupElem<G> Initialize() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        pk = G.generator ^ a;
+        return pk;
+    }
+
+    BitString<n> Hash(GroupElem<G> x) {
+        return H(x);
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge() {
+        ModInt<G.order> r <- ModInt<G.order>;
+        BitString<n> h <- BitString<n>;
+        return [G.generator ^ r, h];
+    }
+}
+
+export as HashedDDH;

--- a/Games/Misc/UniqueSampling.game
+++ b/Games/Misc/UniqueSampling.game
@@ -1,14 +1,17 @@
-Game Replacement(Int lambda) {
-    BitString<lambda> Samp(Set<BitString<lambda>> bookkeeping) {
-        BitString<lambda> r <- BitString<lambda>;
-        return r;
+// Assumption: sampling uniformly from a set S is indistinguishable from
+// sampling from S \ bookkeeping.
+
+Game Replacement(Set S) {
+    S Samp(Set<S> bookkeeping) {
+        S val <- S;
+        return val;
     }
 }
 
-Game NoReplacement(Int lambda) {
-    BitString<lambda> Samp(Set<BitString<lambda>> bookkeeping) {
-        BitString<lambda> r <-uniq[bookkeeping] BitString<lambda>;
-        return r;
+Game NoReplacement(Set S) {
+    S Samp(Set<S> bookkeeping) {
+        S val <-uniq[bookkeeping] S;
+        return val;
     }
 }
 

--- a/Games/PRF/Security.game
+++ b/Games/PRF/Security.game
@@ -12,10 +12,10 @@ Game Real(PRF F) {
 }
 
 Game Random(PRF F) {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     BitString<F.out> Lookup(BitString<F.in> x) {

--- a/Games/PubKeyEnc/CPAROM.game
+++ b/Games/PubKeyEnc/CPAROM.game
@@ -1,0 +1,45 @@
+// CPA security in the Random Oracle Model.
+// Like standard CPA, but the adversary also gets a Hash oracle
+// exposing the random function H used by the encryption scheme.
+// H is passed as a parameter and shared with the scheme via the
+// proof's let block.
+
+import '../../Primitives/PubKeyEnc.primitive';
+
+Game Left(PubKeyEnc E, Set D, Set R, Function<D, R> H) {
+    E.PublicKey pk;
+
+    E.PublicKey Initialize() {
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
+        pk = k[0];
+        return pk;
+    }
+
+    R Hash(D x) {
+        return H(x);
+    }
+
+    E.Ciphertext Challenge(E.Message mL, E.Message mR) {
+        return E.Enc(pk, mL);
+    }
+}
+
+Game Right(PubKeyEnc E, Set D, Set R, Function<D, R> H) {
+    E.PublicKey pk;
+
+    E.PublicKey Initialize() {
+        [E.PublicKey, E.SecretKey] k = E.KeyGen();
+        pk = k[0];
+        return pk;
+    }
+
+    R Hash(D x) {
+        return H(x);
+    }
+
+    E.Ciphertext Challenge(E.Message mL, E.Message mR) {
+        return E.Enc(pk, mR);
+    }
+}
+
+export as CPAROM;

--- a/Proofs/PubEnc/HashedDDHFromDDH.proof
+++ b/Proofs/PubEnc/HashedDDHFromDDH.proof
@@ -1,0 +1,82 @@
+// HashedDDH follows from DDH + UniqueSampling in the random oracle model.
+//
+// H is sampled as a random function. DDH replaces the DH shared secret
+// with a random group element c. UniqueSampling switches from uniform
+// to exclusion sampling (explicit q/|D| guessing loss). With c excluded
+// from all adversary hash queries, H(c) is exactly an independent
+// uniform bitstring.
+//
+// Game sequence:
+//   HashedDDH.Left                          -- [g^r, H(pk^r)]
+//   DDH.Left  o R_DDH                       -- same by interchangeability
+//   DDH.Right o R_DDH                       -- by DDH: pk^r -> random c
+//   UniqueSampling.Replacement  o R_Uniq    -- interchangeability (uniform c)
+//   UniqueSampling.NoReplacement o R_Uniq   -- by UniqueSampling (q/|D| loss)
+//   HashedDDH.Right                         -- H(c_uniq) -> random (exact)
+
+import '../../Games/Group/DDH.game';
+import '../../Games/Misc/UniqueSampling.game';
+import '../../Games/Group/HashedDDH.game';
+
+// DDH reduction: hashes the DDH challenge value and forwards the Hash oracle.
+Reduction R_DDH(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose DDH(G) against HashedDDH(G, n, H).Adversary {
+    GroupElem<G> Initialize(GroupElem<G> pk) {
+        return pk;
+    }
+
+    BitString<n> Hash(GroupElem<G> x) {
+        return H(x);
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge() {
+        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
+        return [pair[0], H(pair[1])];
+    }
+}
+
+// UniqueSampling reduction: delegates sampling to the UniqueSampling challenger,
+// using H.domain (implicitly maintained) as the bookkeeping set.
+Reduction R_Uniq(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose UniqueSampling(GroupElem<G>) against HashedDDH(G, n, H).Adversary {
+    GroupElem<G> pk;
+
+    GroupElem<G> Initialize() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        pk = G.generator ^ a;
+        return pk;
+    }
+
+    BitString<n> Hash(GroupElem<G> x) {
+        return H(x);
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge() {
+        ModInt<G.order> r <- ModInt<G.order>;
+        GroupElem<G> c = challenger.Samp(H.domain);
+        return [G.generator ^ r, H(c)];
+    }
+}
+
+proof:
+
+let:
+    Group G;
+    Int n;
+    Function<GroupElem<G>, BitString<n>> H <- Function<GroupElem<G>, BitString<n>>;
+
+assume:
+    DDH(G);
+    UniqueSampling(GroupElem<G>);
+
+theorem:
+    HashedDDH(G, n, H);
+
+games:
+    HashedDDH(G, n, H).Left against HashedDDH(G, n, H).Adversary;
+
+    DDH(G).Left compose R_DDH(G, n, H) against HashedDDH(G, n, H).Adversary;
+    DDH(G).Right compose R_DDH(G, n, H) against HashedDDH(G, n, H).Adversary;
+
+    UniqueSampling(GroupElem<G>).Replacement compose R_Uniq(G, n, H) against HashedDDH(G, n, H).Adversary;
+    UniqueSampling(GroupElem<G>).NoReplacement compose R_Uniq(G, n, H) against HashedDDH(G, n, H).Adversary;
+
+    HashedDDH(G, n, H).Right against HashedDDH(G, n, H).Adversary;

--- a/Proofs/PubEnc/HashedElGamalCPA.proof
+++ b/Proofs/PubEnc/HashedElGamalCPA.proof
@@ -1,0 +1,72 @@
+// Main result: Hashed ElGamal is IND-CPA secure under the Hashed DDH assumption.
+//
+// This is a standard model proof. H is an abstract known function
+// (not sampled), and HashedDDH is assumed directly.
+//
+// High-level proof idea:
+// HashedDDH replaces H(pk^r) with a random bitstring.
+// Once the hash output is replaced by a uniform random value,
+// the XOR masking makes the ciphertext independent of the message.
+//
+// Game sequence:
+//   CPA.Left                        -- [g^r, H(pk^r) + mL]
+//   HashedDDH.Left  o R_L           -- same by interchangeability
+//   HashedDDH.Right o R_L           -- by HashedDDH: H(pk^r) -> random h; h+mL -> h
+//   HashedDDH.Right o R_R           -- same (both canonicalize to [g^r, h])
+//   HashedDDH.Left  o R_R           -- by HashedDDH (reverse)
+//   CPA.Right                       -- [g^r, H(pk^r) + mR]
+
+import '../../Primitives/PubKeyEnc.primitive';
+import '../../Games/PubKeyEnc/CPA.game';
+import '../../Games/Group/HashedDDH.game';
+import '../../Schemes/PubEnc/HashedElGamal.scheme';
+
+// HashedDDH reduction (left message): XORs the hashed DH value with mL.
+Reduction R_L(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose HashedDDH(G, n, H) against CPA(HashedElGamal(G, n, H)).Adversary {
+    GroupElem<G> Initialize(GroupElem<G> pk) {
+        return pk;
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
+        [GroupElem<G>, BitString<n>] pair = challenger.Challenge();
+        return [pair[0], pair[1] + mL];
+    }
+}
+
+// HashedDDH reduction (right message): XORs the hashed DH value with mR.
+Reduction R_R(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose HashedDDH(G, n, H) against CPA(HashedElGamal(G, n, H)).Adversary {
+    GroupElem<G> Initialize(GroupElem<G> pk) {
+        return pk;
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
+        [GroupElem<G>, BitString<n>] pair = challenger.Challenge();
+        return [pair[0], pair[1] + mR];
+    }
+}
+
+proof:
+
+let:
+    Group G;
+    Int n;
+    Function<GroupElem<G>, BitString<n>> H;
+    PubKeyEnc E = HashedElGamal(G, n, H);
+
+assume:
+    HashedDDH(G, n, H);
+
+theorem:
+    CPA(E);
+
+games:
+    CPA(E).Left against CPA(E).Adversary;
+
+    HashedDDH(G, n, H).Left compose R_L(G, n, H) against CPA(E).Adversary;
+    HashedDDH(G, n, H).Right compose R_L(G, n, H) against CPA(E).Adversary;
+
+    HashedDDH(G, n, H).Right compose R_R(G, n, H) against CPA(E).Adversary;
+
+    HashedDDH(G, n, H).Left compose R_R(G, n, H) against CPA(E).Adversary;
+
+    CPA(E).Right against CPA(E).Adversary;

--- a/Proofs/PubEnc/HashedElGamalCPAROM.proof
+++ b/Proofs/PubEnc/HashedElGamalCPAROM.proof
@@ -1,0 +1,137 @@
+// Hashed ElGamal is IND-CPA secure under DDH + UniqueSampling in the ROM.
+//
+// H is sampled as a random function (ROM). The adversary gets a Hash
+// oracle via the CPAROM game. DDH replaces the DH shared secret with
+// a random group element c. UniqueSampling switches from uniform to
+// exclusion sampling (explicit q/|D| guessing loss). With c excluded
+// from adversary queries, H(c) is exactly a random bitstring that
+// masks the message via XOR.
+//
+// Game sequence (symmetric around the middle):
+//   CPAROM.Left
+//   DDH.Left  o R_L                           -- interchangeability
+//   DDH.Right o R_L                           -- by DDH
+//   US.Replacement o R_Uniq_L                 -- interchangeability
+//   US.NoReplacement o R_Uniq_L               -- by UniqueSampling (q/|D| loss)
+//   US.NoReplacement o R_Uniq_R               -- exact (FreshInputRFToUniform)
+//   US.Replacement o R_Uniq_R                 -- by UniqueSampling (reverse)
+//   DDH.Right o R_R                           -- interchangeability
+//   DDH.Left  o R_R                           -- by DDH (reverse)
+//   CPAROM.Right
+
+import '../../Primitives/PubKeyEnc.primitive';
+import '../../Games/Group/DDH.game';
+import '../../Games/Misc/UniqueSampling.game';
+import '../../Games/PubKeyEnc/CPAROM.game';
+import '../../Schemes/PubEnc/HashedElGamal.scheme';
+
+// DDH reduction (left message): forwards Hash oracle, XORs H(DDH value) with mL.
+Reduction R_L(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose DDH(G) against CPAROM(HashedElGamal(G, n, H), GroupElem<G>, BitString<n>, H).Adversary {
+    GroupElem<G> Initialize(GroupElem<G> pk) {
+        return pk;
+    }
+
+    BitString<n> Hash(GroupElem<G> x) {
+        return H(x);
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
+        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
+        BitString<n> h = H(pair[1]);
+        return [pair[0], h + mL];
+    }
+}
+
+// DDH reduction (right message): forwards Hash oracle, XORs H(DDH value) with mR.
+Reduction R_R(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose DDH(G) against CPAROM(HashedElGamal(G, n, H), GroupElem<G>, BitString<n>, H).Adversary {
+    GroupElem<G> Initialize(GroupElem<G> pk) {
+        return pk;
+    }
+
+    BitString<n> Hash(GroupElem<G> x) {
+        return H(x);
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
+        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
+        BitString<n> h = H(pair[1]);
+        return [pair[0], h + mR];
+    }
+}
+
+// UniqueSampling reduction (left message): delegates c-sampling to US challenger.
+Reduction R_Uniq_L(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose UniqueSampling(GroupElem<G>) against CPAROM(HashedElGamal(G, n, H), GroupElem<G>, BitString<n>, H).Adversary {
+    GroupElem<G> pk;
+
+    GroupElem<G> Initialize() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        pk = G.generator ^ a;
+        return pk;
+    }
+
+    BitString<n> Hash(GroupElem<G> x) {
+        return H(x);
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
+        ModInt<G.order> r <- ModInt<G.order>;
+        GroupElem<G> c = challenger.Samp(H.domain);
+        BitString<n> h = H(c);
+        return [G.generator ^ r, h + mL];
+    }
+}
+
+// UniqueSampling reduction (right message): delegates c-sampling to US challenger.
+Reduction R_Uniq_R(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose UniqueSampling(GroupElem<G>) against CPAROM(HashedElGamal(G, n, H), GroupElem<G>, BitString<n>, H).Adversary {
+    GroupElem<G> pk;
+
+    GroupElem<G> Initialize() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        pk = G.generator ^ a;
+        return pk;
+    }
+
+    BitString<n> Hash(GroupElem<G> x) {
+        return H(x);
+    }
+
+    [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
+        ModInt<G.order> r <- ModInt<G.order>;
+        GroupElem<G> c = challenger.Samp(H.domain);
+        BitString<n> h = H(c);
+        return [G.generator ^ r, h + mR];
+    }
+}
+
+proof:
+
+let:
+    Group G;
+    Int n;
+    Function<GroupElem<G>, BitString<n>> H <- Function<GroupElem<G>, BitString<n>>;
+    PubKeyEnc E = HashedElGamal(G, n, H);
+
+assume:
+    DDH(G);
+    UniqueSampling(GroupElem<G>);
+
+theorem:
+    CPAROM(E, GroupElem<G>, BitString<n>, H);
+
+games:
+    CPAROM(E, GroupElem<G>, BitString<n>, H).Left against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+
+    DDH(G).Left compose R_L(G, n, H) against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+    DDH(G).Right compose R_L(G, n, H) against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+
+    UniqueSampling(GroupElem<G>).Replacement compose R_Uniq_L(G, n, H) against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+    UniqueSampling(GroupElem<G>).NoReplacement compose R_Uniq_L(G, n, H) against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+
+    UniqueSampling(GroupElem<G>).NoReplacement compose R_Uniq_R(G, n, H) against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+
+    UniqueSampling(GroupElem<G>).Replacement compose R_Uniq_R(G, n, H) against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+
+    DDH(G).Right compose R_R(G, n, H) against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+    DDH(G).Left compose R_R(G, n, H) against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;
+
+    CPAROM(E, GroupElem<G>, BitString<n>, H).Right against CPAROM(E, GroupElem<G>, BitString<n>, H).Adversary;

--- a/Proofs/SymEnc/SymEncPRFCPA$.proof
+++ b/Proofs/SymEnc/SymEncPRFCPA$.proof
@@ -45,10 +45,10 @@ Reduction R_PRF(SymEnc E, PRF F) compose PRFSecurity(F) against CPA$(E).Adversar
 
 // G_RF: PRF replaced by a random function
 Game G_RF(SymEnc E, PRF F) {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -58,11 +58,11 @@ Game G_RF(SymEnc E, PRF F) {
 }
 
 // Reduction for forward UniqueSampling hop: delegates r-sampling to challenger
-Reduction R_Uniq(SymEnc E, PRF F) compose UniqueSampling(F.in) against CPA$(E).Adversary {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+Reduction R_Uniq(SymEnc E, PRF F) compose UniqueSampling(BitString<F.in>) against CPA$(E).Adversary {
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -73,10 +73,10 @@ Reduction R_Uniq(SymEnc E, PRF F) compose UniqueSampling(F.in) against CPA$(E).A
 
 // G_Uniq: unique sampling guarantees distinct RF inputs
 Game G_Uniq(SymEnc E, PRF F) {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -90,10 +90,10 @@ Game G_Uniq(SymEnc E, PRF F) {
 //   1. UniqueRF: RF(r) -> z <- BitString<F.out> (r uniquely sampled)
 //   2. UniformXOR: m + z -> z (z is uniform)
 Game G_UniqSimp(SymEnc E, PRF F) {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -104,11 +104,11 @@ Game G_UniqSimp(SymEnc E, PRF F) {
 }
 
 // Reduction for reverse UniqueSampling hop: r from challenger, z sampled uniformly
-Reduction R_Uniq2(SymEnc E, PRF F) compose UniqueSampling(F.in) against CPA$(E).Adversary {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+Reduction R_Uniq2(SymEnc E, PRF F) compose UniqueSampling(BitString<F.in>) against CPA$(E).Adversary {
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -138,7 +138,7 @@ let:
 
 assume:
     PRFSecurity(F);
-    UniqueSampling(F.in);
+    UniqueSampling(BitString<F.in>);
 
 theorem:
     CPA$(E);
@@ -157,10 +157,10 @@ games:
     G_RF(E, F) against CPA$(E).Adversary;
 
     // Interchangeability: extract r-sampling to challenger
-    UniqueSampling(F.in).Replacement compose R_Uniq(E, F) against CPA$(E).Adversary;
+    UniqueSampling(BitString<F.in>).Replacement compose R_Uniq(E, F) against CPA$(E).Adversary;
 
     // By UniqueSampling assumption (forward): sample r without replacement
-    UniqueSampling(F.in).NoReplacement compose R_Uniq(E, F) against CPA$(E).Adversary;
+    UniqueSampling(BitString<F.in>).NoReplacement compose R_Uniq(E, F) against CPA$(E).Adversary;
 
     // Interchangeability: inline unique sampling
     G_Uniq(E, F) against CPA$(E).Adversary;
@@ -169,10 +169,10 @@ games:
     G_UniqSimp(E, F) against CPA$(E).Adversary;
 
     // Interchangeability: extract r-sampling to challenger
-    UniqueSampling(F.in).NoReplacement compose R_Uniq2(E, F) against CPA$(E).Adversary;
+    UniqueSampling(BitString<F.in>).NoReplacement compose R_Uniq2(E, F) against CPA$(E).Adversary;
 
     // By UniqueSampling assumption (reverse): sample r with replacement
-    UniqueSampling(F.in).Replacement compose R_Uniq2(E, F) against CPA$(E).Adversary;
+    UniqueSampling(BitString<F.in>).Replacement compose R_Uniq2(E, F) against CPA$(E).Adversary;
 
     // Interchangeability: inline uniform sampling
     G_Uniform(E, F) against CPA$(E).Adversary;

--- a/Proofs/SymEnc/SymEncPRFOTUC.proof
+++ b/Proofs/SymEnc/SymEncPRFOTUC.proof
@@ -48,10 +48,10 @@ Reduction R_PRF(SymEnc E, PRF F) compose PRFSecurity(F) against OneTimeUniformCi
 
 // Intermediate game: PRF replaced by random function
 Game G_RF(SymEnc E, PRF F) {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -62,11 +62,11 @@ Game G_RF(SymEnc E, PRF F) {
 }
 
 // Reduction for forward UniqueSampling hop (Replacement -> NoReplacement on r)
-Reduction R_Sample(SymEnc E, PRF F) compose UniqueSampling(F.in) against OneTimeUniformCiphertexts(E).Adversary {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+Reduction R_Sample(SymEnc E, PRF F) compose UniqueSampling(BitString<F.in>) against OneTimeUniformCiphertexts(E).Adversary {
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -78,10 +78,10 @@ Reduction R_Sample(SymEnc E, PRF F) compose UniqueSampling(F.in) against OneTime
 
 // Intermediate game: unique sampling with RF
 Game G_Uniq(SymEnc E, PRF F) {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -95,11 +95,11 @@ Game G_Uniq(SymEnc E, PRF F) {
 // After UniqueRFSimplification, z = RF(r) becomes z <- uniform,
 // so this reduction just samples z uniformly and delegates r to challenger.
 // RF field is retained for domain bookkeeping even though it is not called.
-Reduction R_Sample2(SymEnc E, PRF F) compose UniqueSampling(F.in) against OneTimeUniformCiphertexts(E).Adversary {
-    RandomFunctions<BitString<F.in>, BitString<F.out>> RF;
+Reduction R_Sample2(SymEnc E, PRF F) compose UniqueSampling(BitString<F.in>) against OneTimeUniformCiphertexts(E).Adversary {
+    Function<BitString<F.in>, BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<BitString<F.in>, BitString<F.out>>;
+        RF <- Function<BitString<F.in>, BitString<F.out>>;
     }
 
     E.Ciphertext CTXT(E.Message m) {
@@ -121,7 +121,7 @@ let:
 
 assume:
     PRFSecurity(F);
-    UniqueSampling(F.in);
+    UniqueSampling(BitString<F.in>);
     calls <= 1;
 
 theorem:
@@ -144,19 +144,19 @@ games:
     G_RF(E, F) against OneTimeUniformCiphertexts(E).Adversary;
 
     // Interchangeability
-    UniqueSampling(F.in).Replacement compose R_Sample(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+    UniqueSampling(BitString<F.in>).Replacement compose R_Sample(E, F) against OneTimeUniformCiphertexts(E).Adversary;
 
     // By UniqueSampling assumption (forward: Replacement -> NoReplacement)
-    UniqueSampling(F.in).NoReplacement compose R_Sample(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+    UniqueSampling(BitString<F.in>).NoReplacement compose R_Sample(E, F) against OneTimeUniformCiphertexts(E).Adversary;
 
     // Interchangeability
     G_Uniq(E, F) against OneTimeUniformCiphertexts(E).Adversary;
 
     // Interchangeability (engine: UniqueRF simplification, RF(r) -> z <- R)
-    UniqueSampling(F.in).NoReplacement compose R_Sample2(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+    UniqueSampling(BitString<F.in>).NoReplacement compose R_Sample2(E, F) against OneTimeUniformCiphertexts(E).Adversary;
 
     // By UniqueSampling assumption (reverse: NoReplacement -> Replacement)
-    UniqueSampling(F.in).Replacement compose R_Sample2(E, F) against OneTimeUniformCiphertexts(E).Adversary;
+    UniqueSampling(BitString<F.in>).Replacement compose R_Sample2(E, F) against OneTimeUniformCiphertexts(E).Adversary;
 
     // Interchangeability: uniform r, uniform z, m + z -> uniform = OTUC.Random
     OneTimeUniformCiphertexts(E).Random against OneTimeUniformCiphertexts(E).Adversary;

--- a/Schemes/PubEnc/HashedElGamal.scheme
+++ b/Schemes/PubEnc/HashedElGamal.scheme
@@ -1,0 +1,28 @@
+// Hashed ElGamal encryption in the random oracle model.
+// The hash function H is modeled as a Function parameter,
+// shared with the security game via the proof's let block.
+
+import '../../Primitives/PubKeyEnc.primitive';
+
+Scheme HashedElGamal(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) extends PubKeyEnc {
+    Set Message = BitString<n>;
+    Set Ciphertext = [GroupElem<G>, BitString<n>];
+    Set PublicKey = GroupElem<G>;
+    Set SecretKey = ModInt<G.order>;
+
+    [PublicKey, SecretKey] KeyGen() {
+        ModInt<G.order> a <- ModInt<G.order>;
+        return [G.generator ^ a, a];
+    }
+
+    Ciphertext Enc(PublicKey pk, Message m) {
+        ModInt<G.order> r <- ModInt<G.order>;
+        BitString<n> h = H(pk ^ r);
+        return [G.generator ^ r, h + m];
+    }
+
+    Message? Dec(SecretKey sk, Ciphertext c) {
+        BitString<n> h = H(c[0] ^ sk);
+        return c[1] + h;
+    }
+}

--- a/applications/KEMCombiner-GHP18/TwoKeyPRFFirstKeySecurity.game
+++ b/applications/KEMCombiner-GHP18/TwoKeyPRFFirstKeySecurity.game
@@ -17,10 +17,10 @@ Game Real(TwoKeyPRF F) {
 }
 
 Game Random(TwoKeyPRF F) {
-    RandomFunctions<[BitString<F.lambda2>, BitString<F.in>], BitString<F.out>> RF;
+    Function<[BitString<F.lambda2>, BitString<F.in>], BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<[BitString<F.lambda2>, BitString<F.in>], BitString<F.out>>;
+        RF <- Function<[BitString<F.lambda2>, BitString<F.in>], BitString<F.out>>;
     }
 
     BitString<F.out> Lookup(BitString<F.lambda2> key2, BitString<F.in> x) {

--- a/applications/KEMCombiner-GHP18/TwoKeyPRFSecondKeySecurity.game
+++ b/applications/KEMCombiner-GHP18/TwoKeyPRFSecondKeySecurity.game
@@ -17,10 +17,10 @@ Game Real(TwoKeyPRF F) {
 }
 
 Game Random(TwoKeyPRF F) {
-    RandomFunctions<[BitString<F.lambda1>, BitString<F.in>], BitString<F.out>> RF;
+    Function<[BitString<F.lambda1>, BitString<F.in>], BitString<F.out>> RF;
 
     Void Initialize() {
-        RF <- RandomFunctions<[BitString<F.lambda1>, BitString<F.in>], BitString<F.out>>;
+        RF <- Function<[BitString<F.lambda1>, BitString<F.in>], BitString<F.out>>;
     }
 
     BitString<F.out> Lookup(BitString<F.lambda1> key1, BitString<F.in> x) {


### PR DESCRIPTION
New files:
- HashedElGamal.scheme: Hashed ElGamal encryption parameterized by Function<GroupElem<G>, BitString<n>> H
- HashedDDH.game: Hashed DDH assumption with Hash oracle
- CPAROM.game: generic CPA game in the ROM with Hash oracle
- HashedElGamalCPA.proof: standard model CPA from HashedDDH
- HashedDDHFromDDH.proof: ROM proof of HashedDDH from DDH + UniqueSampling
- HashedElGamalCPAROM.proof: ROM CPA from DDH + UniqueSampling

Modified files:
- Rename RandomFunctions to Function throughout (language change)
- Generalize UniqueSampling game from BitString<lambda> to generic Set S
- Update SymEncPRF proofs for generalized UniqueSampling