### PR TITLE
Add deterministic/injective modifiers and fix Dec return types

### DIFF
--- a/Book/2/2_12_DoubleOTP.scheme
+++ b/Book/2/2_12_DoubleOTP.scheme
@@ -17,7 +17,7 @@ Scheme DoubleOTP(Int lambda) extends SymEnc {
         return c2;
     }
 
-    Message Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         Ciphertext c1 = k[1] + c;
         Message m = k[0] + c1;
         return m;

--- a/Book/2_Exercises/2_13_SymEncSquared.scheme
+++ b/Book/2_Exercises/2_13_SymEncSquared.scheme
@@ -17,7 +17,7 @@ Scheme SymEncSquared(SymEnc E) extends SymEnc {
         return [c1, c2];
     }
 
-    Message? Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         E.Message? m1 = E.Dec(k[0], c[0]);
         E.Message? m2 = E.Dec(k[1], c[1]);
         if (m1 != m2) {

--- a/Book/5/5_2_PseudoOTP.scheme
+++ b/Book/5/5_2_PseudoOTP.scheme
@@ -17,7 +17,7 @@ Scheme PseudoOTP(Int lambda, Int stretch, PRG G) extends SymEnc {
         return G.evaluate(k) + m;
     }
 
-    Message Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         return G.evaluate(k) + c;
     }
 }

--- a/Book/5_Exercises/5_10.scheme
+++ b/Book/5_Exercises/5_10.scheme
@@ -6,7 +6,7 @@ Scheme PRG_5_10(PRG G) extends PRG {
     Int lambda = G.lambda;
     Int stretch = 2 * G.lambda;
 
-    BitString<lambda + stretch> evaluate(BitString<lambda> s) {
+    deterministic BitString<lambda + stretch> evaluate(BitString<lambda> s) {
         BitString<G.lambda + G.stretch> xy = G.evaluate(s);
         BitString<G.lambda> x = xy[0 : G.lambda];
         BitString<G.lambda> y = xy[G.lambda : 2 * G.lambda];

--- a/Book/5_Exercises/5_8_a.scheme
+++ b/Book/5_Exercises/5_8_a.scheme
@@ -6,7 +6,7 @@ Scheme PRG_5_8_a(PRG G) extends PRG {
     Int lambda = G.lambda;
     Int stretch = 5 * G.lambda;
 
-    BitString<lambda + stretch> evaluate(BitString<lambda> s) {
+    deterministic BitString<lambda + stretch> evaluate(BitString<lambda> s) {
         BitString<3 * lambda> result1 = G.evaluate(s);
 
         BitString<lambda> x = result1[0 : lambda];

--- a/Book/5_Exercises/5_8_b.scheme
+++ b/Book/5_Exercises/5_8_b.scheme
@@ -6,7 +6,7 @@ Scheme PRG_5_8_b(PRG G) extends PRG {
     Int lambda = G.lambda;
     Int stretch = G.lambda;
 
-    BitString<lambda + stretch> evaluate(BitString<lambda> s) {
+    deterministic BitString<lambda + stretch> evaluate(BitString<lambda> s) {
         BitString<3 * lambda> result = G.evaluate(s);
         
         BitString<lambda> x = result[0 : lambda];

--- a/Book/5_Exercises/5_8_e.scheme
+++ b/Book/5_Exercises/5_8_e.scheme
@@ -6,7 +6,7 @@ Scheme PRG_5_8_e(PRG G) extends PRG {
     Int lambda = G.lambda;
     Int stretch = G.stretch;
 
-    BitString<lambda + stretch> evaluate(BitString<lambda> s) {
+    deterministic BitString<lambda + stretch> evaluate(BitString<lambda> s) {
         return G.evaluate(s) + G.evaluate(0b0);
     }
 }

--- a/Book/5_Exercises/5_8_f.scheme
+++ b/Book/5_Exercises/5_8_f.scheme
@@ -6,7 +6,7 @@ Scheme PRG_5_8_f(PRG G) extends PRG {
     Int lambda = 2 * G.lambda; // seed length
     Int stretch = G.lambda;
 
-    BitString<lambda + stretch> evaluate(BitString<lambda> s) {
+    deterministic BitString<lambda + stretch> evaluate(BitString<lambda> s) {
         BitString<G.lambda> sL = s[0 : G.lambda];
         BitString<G.lambda> sR = s[G.lambda : lambda];
         return G.evaluate(sL) + G.evaluate(sR);

--- a/Schemes/KEM/KEMPRF.scheme
+++ b/Schemes/KEM/KEMPRF.scheme
@@ -22,7 +22,7 @@ Scheme KEMPRF(KEM K, PRF F) extends KEM {
         return [ss, c];
     }
 
-    SharedSecret Decaps(SecretKey sk, Ciphertext c) {
+    deterministic SharedSecret Decaps(SecretKey sk, Ciphertext c) {
         K.SharedSecret k = K.Decaps(sk, c);
         BitString<F.out> ss = F.evaluate(k, c);
         return ss;

--- a/Schemes/PRG/TriplingPRG.scheme
+++ b/Schemes/PRG/TriplingPRG.scheme
@@ -6,7 +6,7 @@ Scheme TriplingPRG(PRG G) extends PRG {
     Int lambda = G.lambda;
     Int stretch = 2 * G.lambda;
 
-    BitString<lambda + stretch> evaluate(BitString<lambda> s) {
+    deterministic BitString<lambda + stretch> evaluate(BitString<lambda> s) {
         BitString<2 * lambda> result1 = G.evaluate(s);
         BitString<lambda> x = result1[0 : lambda];
         BitString<lambda> y = result1[lambda : 2*lambda];

--- a/Schemes/PubEnc/ElGamal.scheme
+++ b/Schemes/PubEnc/ElGamal.scheme
@@ -16,7 +16,7 @@ Scheme ElGamal(Group G) extends PubKeyEnc {
         return [G.generator ^ r, m * pk ^ r];
     }
 
-    Message? Dec(SecretKey sk, Ciphertext c) {
+    deterministic Message? Dec(SecretKey sk, Ciphertext c) {
         return c[1] / c[0] ^ sk;
     }
 }

--- a/Schemes/PubEnc/HashedElGamal.scheme
+++ b/Schemes/PubEnc/HashedElGamal.scheme
@@ -21,7 +21,7 @@ Scheme HashedElGamal(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) ext
         return [G.generator ^ r, h + m];
     }
 
-    Message? Dec(SecretKey sk, Ciphertext c) {
+    deterministic Message? Dec(SecretKey sk, Ciphertext c) {
         BitString<n> h = H(c[0] ^ sk);
         return c[1] + h;
     }

--- a/Schemes/PubEnc/Hybrid.scheme
+++ b/Schemes/PubEnc/Hybrid.scheme
@@ -20,7 +20,7 @@ Scheme Hybrid(SymEnc E, PubKeyEnc P) extends PubKeyEnc {
         return [cpub, csym];
     }
 
-    Message? Dec(SecretKey sk, Ciphertext c) {
+    deterministic Message? Dec(SecretKey sk, Ciphertext c) {
         E.Key? tk = P.Dec(sk, c[0]);
         if (tk == None) {
             return None;

--- a/Schemes/PubEnc/KEMDEM.scheme
+++ b/Schemes/PubEnc/KEMDEM.scheme
@@ -31,7 +31,7 @@ Scheme KEMDEM(KEM K, SymEnc E) extends PubKeyEnc {
         return [c_kem, c_sym];
     }
 
-    Message? Dec(SecretKey sk, Ciphertext c) {
+    deterministic Message? Dec(SecretKey sk, Ciphertext c) {
         K.Ciphertext c_kem = c[0];
         E.Ciphertext c_sym = c[1];
         K.SharedSecret k_sym = K.Decaps(sk, c_kem);

--- a/Schemes/SymEnc/DoubleSymEnc.scheme
+++ b/Schemes/SymEnc/DoubleSymEnc.scheme
@@ -19,7 +19,7 @@ Scheme DoubleSymEnc(SymEnc s) extends SymEnc {
         return c2;
     }
 
-    Message Dec(Key k, Ciphertext c) {
+    deterministic Message Dec(Key k, Ciphertext c) {
         Ciphertext c2 = s.Dec(k[1], c);
         Message m = s.Dec(k[0], c2);
         return m;

--- a/Schemes/SymEnc/EncryptThenMAC.scheme
+++ b/Schemes/SymEnc/EncryptThenMAC.scheme
@@ -21,7 +21,7 @@ Scheme EncryptThenMAC(SymEnc E, MAC M) extends SymEnc {
         return [c, t];
     }
 
-    Message? Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         if (c[1] != M.MAC(k[1], c[0])) {
             return None;
         }

--- a/Schemes/SymEnc/GeneralDoubleSymEnc.scheme
+++ b/Schemes/SymEnc/GeneralDoubleSymEnc.scheme
@@ -19,7 +19,7 @@ Scheme GeneralDoubleSymEnc(SymEnc S, SymEnc T) extends SymEnc {
         return c2;
     }
 
-    Message Dec(Key k, Ciphertext c) {
+    deterministic Message Dec(Key k, Ciphertext c) {
         S.Ciphertext c2 = T.Dec(k[1], c);
         S.Message m = S.Dec(k[0], c2);
         return m;

--- a/Schemes/SymEnc/ModOTP.scheme
+++ b/Schemes/SymEnc/ModOTP.scheme
@@ -14,7 +14,7 @@ Scheme ModOTP(Int q) extends SymEnc {
         return k + m;
     }
 
-    Message Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         return c - k;
     }
 }

--- a/Schemes/SymEnc/OTP.scheme
+++ b/Schemes/SymEnc/OTP.scheme
@@ -14,7 +14,7 @@ Scheme OTP(Int lambda) extends SymEnc {
         return k + m;
     }
 
-    Message Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         return k + c;
     }
 }

--- a/Schemes/SymEnc/SymEncPRF.scheme
+++ b/Schemes/SymEnc/SymEncPRF.scheme
@@ -19,7 +19,7 @@ Scheme SymEncPRF(PRF F) extends SymEnc {
         return [r, m + z];
     }
 
-    Message Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         Message m = F.evaluate(k, c[0]) + c[1];
         return m;
     }

--- a/applications/KEMCombiner-GHP18/KEMCombiner.scheme
+++ b/applications/KEMCombiner-GHP18/KEMCombiner.scheme
@@ -44,7 +44,7 @@ Scheme KEMCombiner(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int 
         return [ss, [ct1, ct2]];
     }
 
-    SharedSecret Decaps(SecretKey sk, Ciphertext c) {
+    deterministic SharedSecret Decaps(SecretKey sk, Ciphertext c) {
         KEM1.SecretKey sk1 = sk[0];
         KEM2.SecretKey sk2 = sk[1];
         KEM1.PublicKey pk1 = sk[2];

--- a/joy/Schemes/SymEnc/ChainedEncryption.scheme
+++ b/joy/Schemes/SymEnc/ChainedEncryption.scheme
@@ -24,7 +24,7 @@ Scheme ChainedEncryption(SymEnc E1, SymEnc E2) extends SymEnc {
         return [c1, c2];
     }
 
-    Message? Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         E2.Key? kprime = E1.Dec(k, c[0]);
         if (kprime == None) {
             return None;

--- a/joy/Schemes/SymEnc/OTP.scheme
+++ b/joy/Schemes/SymEnc/OTP.scheme
@@ -18,7 +18,7 @@ Scheme OTP(Int lambda) extends SymEnc {
         return k + m;
     }
 
-    Message Dec(Key k, Ciphertext c) {
+    deterministic Message? Dec(Key k, Ciphertext c) {
         return k + c;
     }
 }


### PR DESCRIPTION
Update example schemes to satisfy the stricter scheme/primitive consistency check that the ProofFrog typechecker now enforces. Each scheme that extends a primitive must declare exactly the same `deterministic`/`injective` modifiers and matching return/parameter types as the primitive, including not substituting `T` for `T?`.

- Add `deterministic` to PRG `evaluate` implementations (Schemes/PRG/TriplingPRG, Book/5_Exercises/5_8_{a,b,e,f}, Book/5_Exercises/5_10).
- Add `deterministic` to KEM `Decaps` implementations (Schemes/KEM/KEMPRF, applications/KEMCombiner-GHP18/KEMCombiner).
- Add `deterministic` to PubKeyEnc `Dec` implementations (Schemes/PubEnc/ElGamal, HashedElGamal, Hybrid, KEMDEM).
- Add `deterministic` to SymEnc `Dec` implementations (Schemes/SymEnc/DoubleSymEnc, GeneralDoubleSymEnc, EncryptThenMAC, Book/2_Exercises/2_13_SymEncSquared, joy/Schemes/SymEnc/ChainedEncryption).
- Add `deterministic` and change `Dec` return type from `Message` to `Message?` for SymEnc schemes whose primitive declares the optional return (Schemes/SymEnc/OTP, ModOTP, SymEncPRF, Book/2/2_12_DoubleOTP, Book/5/5_2_PseudoOTP, joy/Schemes/SymEnc/OTP).

These edits do not change the runtime behavior of any scheme; they only make declared modifiers and return types match the primitive interfaces the schemes were already implementing.