### PR TITLE
Add descriptive comments to example files and rename Fake -> Ideal in correctness games

### DIFF
--- a/Games/MAC/SUFCMA.game
+++ b/Games/MAC/SUFCMA.game
@@ -1,3 +1,7 @@
+// Strong unforgeability under chosen message attack (SUF-CMA) for MACs.
+// Real: CheckTag verifies against the actual MAC computation.
+// Ideal: CheckTag only accepts message-tag pairs previously returned by GetTag.
+
 import '../../Primitives/MAC.primitive';
 
 Game Real(MAC E) {

--- a/Games/PRF/PRFSecurity.game
+++ b/Games/PRF/PRFSecurity.game
@@ -1,3 +1,6 @@
+// PRF security: a keyed PRF is indistinguishable from a random function.
+// Real: evaluates the PRF with a secret key. Random: evaluates a truly random function.
+
 import '../../Primitives/PRF.primitive';
 
 Game Real(PRF F) {

--- a/Games/PRF/PRFSecurity_MultiKey.game
+++ b/Games/PRF/PRFSecurity_MultiKey.game
@@ -1,3 +1,6 @@
+// Multi-key PRF security: each query uses a fresh random key.
+// Real: evaluates the PRF with a fresh key per query. Random: returns a uniform random output.
+
 import '../../Primitives/PRF.primitive';
 
 Game Real(PRF F) {

--- a/Games/PRG/PRGSecurity.game
+++ b/Games/PRG/PRGSecurity.game
@@ -1,3 +1,6 @@
+// PRG security: a pseudorandom generator's output is indistinguishable from uniform.
+// Real: evaluates the PRG on a random seed. Random: returns a uniform random string.
+
 import '../../Primitives/PRG.primitive';
 
 Game Real(PRG G) {

--- a/Games/PRP/Correctness.game
+++ b/Games/PRP/Correctness.game
@@ -1,3 +1,6 @@
+// Correctness of a pseudorandom permutation: evaluateInverse undoes evaluate.
+// Real: tests that inverting the output recovers the input. Ideal: always returns true.
+
 import '../../Primitives/PRP.primitive';
 
 Game Real(PRP F) {
@@ -8,7 +11,7 @@ Game Real(PRP F) {
     }
 }
 
-Game Fake(PRP F) {
+Game Ideal(PRP F) {
     Bool test(BitString<F.lambda> seed, BitString<F.blen> input) {
         return true;
     }

--- a/Games/PubKeyEnc/Correctness.game
+++ b/Games/PubKeyEnc/Correctness.game
@@ -1,3 +1,6 @@
+// Correctness of public key encryption: decryption recovers the encrypted message.
+// Real: encrypts then decrypts and checks equality. Ideal: always returns true.
+
 import '../../Primitives/PubKeyEnc.primitive';
 
 Game Real(PubKeyEnc E) {
@@ -18,7 +21,7 @@ Game Real(PubKeyEnc E) {
     }
 }
 
-Game Fake(PubKeyEnc E) {
+Game Ideal(PubKeyEnc E) {
     E.PublicKey pk;
     E.SecretKey sk;
 

--- a/Games/PubKeyEnc/INDCPA$_MultiChal.game
+++ b/Games/PubKeyEnc/INDCPA$_MultiChal.game
@@ -1,3 +1,6 @@
+// Multi-challenge IND-CPA$ (real-or-random) for public key encryption.
+// Real: returns the encryption of the message. Random: returns a uniform random ciphertext.
+
 import '../../Primitives/PubKeyEnc.primitive';
 
 Game Real(PubKeyEnc E) {

--- a/Games/PubKeyEnc/INDCPA.game
+++ b/Games/PubKeyEnc/INDCPA.game
@@ -1,4 +1,5 @@
-// One-time secrecy for public key encryption (single-challenge IND-CPA).
+// Single-challenge IND-CPA (left-or-right) for public key encryption.
+// Left: encrypts mL; Right: encrypts mR. Only the first query is answered.
 
 import '../../Primitives/PubKeyEnc.primitive';
 

--- a/Games/PubKeyEnc/INDCPA_MultiChal.game
+++ b/Games/PubKeyEnc/INDCPA_MultiChal.game
@@ -1,3 +1,6 @@
+// Multi-challenge IND-CPA (left-or-right) for public key encryption.
+// Left: encrypts the left message mL. Right: encrypts the right message mR.
+
 import '../../Primitives/PubKeyEnc.primitive';
 
 Game Left(PubKeyEnc E) {

--- a/Games/SymEnc/Correctness.game
+++ b/Games/SymEnc/Correctness.game
@@ -1,3 +1,6 @@
+// Correctness of symmetric encryption: decryption recovers the encrypted message.
+// Real: encrypts then decrypts and checks equality. Ideal: always returns true.
+
 import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {
@@ -8,7 +11,7 @@ Game Real(SymEnc E) {
     }
 }
 
-Game Fake(SymEnc E) {
+Game Ideal(SymEnc E) {
     Bool Test(E.Key k, E.Message m) {
         return true;
     }

--- a/Games/SymEnc/INDCCA$_MultiChal.game
+++ b/Games/SymEnc/INDCCA$_MultiChal.game
@@ -1,3 +1,7 @@
+// IND-CCA$ (real-or-random chosen ciphertext attack) for symmetric encryption.
+// Real: CTXT encrypts normally; Decrypt decrypts non-challenge ciphertexts.
+// Random: CTXT returns a uniform random ciphertext instead of encrypting.
+
 import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {

--- a/Games/SymEnc/INDCCA_MultiChal.game
+++ b/Games/SymEnc/INDCCA_MultiChal.game
@@ -1,3 +1,7 @@
+// IND-CCA multi-challenge (left-or-right chosen ciphertext attack) for symmetric encryption.
+// Left: Eavesdrop encrypts mL; Decrypt decrypts non-challenge ciphertexts.
+// Right: Eavesdrop encrypts mR instead.
+
 import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {

--- a/Games/SymEnc/INDCPA$_MultiChal.game
+++ b/Games/SymEnc/INDCPA$_MultiChal.game
@@ -1,3 +1,5 @@
+// Multi-challenge IND-CPA$ (real-or-random) for symmetric encryption.
+// Real: encrypts the message. Random: returns a uniform random ciphertext.
 // Joy of Cryptography Chapter 7 calls this "CPA$ security".
 
 import '../../Primitives/SymEnc.primitive';

--- a/Games/SymEnc/INDCPA_MultiChal.game
+++ b/Games/SymEnc/INDCPA_MultiChal.game
@@ -1,3 +1,5 @@
+// Multi-challenge IND-CPA (left-or-right) for symmetric encryption.
+// Left: encrypts mL. Right: encrypts mR.
 // Joy of Cryptography Chapter 7 calls this "CPA security".
 
 import '../../Primitives/SymEnc.primitive';

--- a/Games/SymEnc/INDOT$.game
+++ b/Games/SymEnc/INDOT$.game
@@ -1,3 +1,5 @@
+// One-time IND$ (real-or-random) for symmetric encryption with a fresh key per query.
+// Real: encrypts the message. Random: returns a uniform random ciphertext.
 // Joy of Cryptography Chapter 2 calls this "one-time uniform ciphertexts".
 
 import '../../Primitives/SymEnc.primitive';

--- a/Games/SymEnc/INDOT.game
+++ b/Games/SymEnc/INDOT.game
@@ -1,3 +1,5 @@
+// One-time secrecy (left-or-right) for symmetric encryption with a fresh key per query.
+// Left: encrypts mL. Right: encrypts mR.
 // Joy of Cryptography Definition 2.5.3 calls this "one-time secrecy".
 
 import '../../Primitives/SymEnc.primitive';

--- a/Games/SymEnc/KeyUniformity.game
+++ b/Games/SymEnc/KeyUniformity.game
@@ -1,3 +1,6 @@
+// Key uniformity for symmetric encryption: KeyGen output is indistinguishable from uniform.
+// Real: returns a key from KeyGen. Random: returns a uniformly sampled key.
+
 import '../../Primitives/SymEnc.primitive';
 
 Game Real(SymEnc E) {

--- a/Primitives/Hash.primitive
+++ b/Primitives/Hash.primitive
@@ -1,3 +1,5 @@
+// Hash function primitive parameterized by seed length (lambda) and output length.
+// Provides a deterministic evaluate operation mapping a seed and arbitrary-length input to a fixed-length output.
 Primitive Hash(Int lambda, Int outputLen) {
     Int lambda = lambda;
     Int outputLen = outputLen;

--- a/Primitives/KEM.primitive
+++ b/Primitives/KEM.primitive
@@ -1,3 +1,5 @@
+// Key Encapsulation Mechanism (KEM) primitive.
+// Provides KeyGen (public/secret key pair), Encaps (shared secret + ciphertext), and deterministic Decaps.
 Primitive KEM(Set SharedSecretSpace, Set CiphertextSpace, Set PKeySpace, Set SKeySpace) {
     Set SharedSecret = SharedSecretSpace;
     Set Ciphertext = CiphertextSpace;

--- a/Primitives/MAC.primitive
+++ b/Primitives/MAC.primitive
@@ -1,3 +1,5 @@
+// Message Authentication Code (MAC) primitive.
+// Provides KeyGen and a deterministic MAC operation that tags a message under a key.
 Primitive MAC(Set MessageSpace, Set TagSpace, Set KeySpace) {
     Set Message = MessageSpace;
     Set Tag = TagSpace;

--- a/Primitives/NonNullableSymEnc.primitive
+++ b/Primitives/NonNullableSymEnc.primitive
@@ -1,3 +1,5 @@
+// Symmetric encryption primitive where Dec always returns a message (never None).
+// Provides KeyGen, Enc, and deterministic Dec with a non-optional return type.
 Primitive SymEnc(Set MessageSpace, Set CiphertextSpace, Set KeySpace) {
     Set Message = MessageSpace;
     Set Ciphertext = CiphertextSpace;

--- a/Primitives/PRF.primitive
+++ b/Primitives/PRF.primitive
@@ -1,3 +1,5 @@
+// Pseudorandom Function (PRF) primitive parameterized by seed length, input length, and output length.
+// Provides a deterministic evaluate operation mapping a seed and input to a fixed-length output.
 Primitive PRF(Int lambda, Int in, Int out) {
     Int lambda = lambda;
     Int in = in;

--- a/Primitives/PRG.primitive
+++ b/Primitives/PRG.primitive
@@ -1,3 +1,5 @@
+// Pseudorandom Generator (PRG) primitive parameterized by seed length (lambda) and stretch.
+// Provides a deterministic evaluate operation that expands a lambda-bit seed to a (lambda + stretch)-bit output.
 Primitive PRG(Int lambda, Int stretch) {
     Int lambda = lambda;
     Int stretch = stretch;

--- a/Primitives/PRP.primitive
+++ b/Primitives/PRP.primitive
@@ -1,3 +1,5 @@
+// Pseudorandom Permutation (PRP) primitive parameterized by seed length (lambda) and block length (blen).
+// Provides deterministic injective evaluate and evaluateInverse operations (a keyed bijection on blen-bit blocks).
 Primitive PRP(Int lambda, Int blen) {
     Int lambda = lambda;
     Int blen = blen;

--- a/Primitives/PubKeyEnc.primitive
+++ b/Primitives/PubKeyEnc.primitive
@@ -1,3 +1,5 @@
+// Public-key encryption primitive.
+// Provides KeyGen (public/secret key pair), Enc (encrypt under public key), and deterministic Dec (returns Message?).
 Primitive PubKeyEnc(Set MessageSpace, Set CiphertextSpace, Set PKeySpace, Set SKeySpace) {
     Set Message = MessageSpace;
     Set Ciphertext = CiphertextSpace;

--- a/Primitives/SymEnc.primitive
+++ b/Primitives/SymEnc.primitive
@@ -1,3 +1,5 @@
+// Symmetric encryption primitive.
+// Provides KeyGen, Enc, and deterministic Dec (returns Message?, allowing decryption failure).
 Primitive SymEnc(Set MessageSpace, Set CiphertextSpace, Set KeySpace) {
     Set Message = MessageSpace;
     Set Ciphertext = CiphertextSpace;

--- a/Proofs/PRG/TriplingPRG_PRGSecurity.proof
+++ b/Proofs/PRG/TriplingPRG_PRGSecurity.proof
@@ -1,3 +1,9 @@
+// Proves that the tripling PRG construction (applying a length-doubling PRG G twice
+// to produce 3*lambda bits from a lambda-bit seed) is a secure PRG.
+// Assumes: PRGSecurity(G) for the underlying length-doubling PRG.
+// Strategy: Two reduction hops replace the two applications of G with random strings,
+// first the initial application and then the second, arriving at a fully random output.
+
 import '../../Primitives/PRG.primitive';
 import '../../Schemes/PRG/TriplingPRG.scheme';
 import '../../Games/PRG/PRGSecurity.game';

--- a/Proofs/PubKeyEnc/ElGamal_Correctness.proof
+++ b/Proofs/PubKeyEnc/ElGamal_Correctness.proof
@@ -24,4 +24,4 @@ theorem:
 games:
     Correctness(E).Real against Correctness(E).Adversary;
 
-    Correctness(E).Fake against Correctness(E).Adversary;
+    Correctness(E).Ideal against Correctness(E).Adversary;

--- a/Proofs/PubKeyEnc/HybridPKEDEM_INDCPA_MultiChal.proof
+++ b/Proofs/PubKeyEnc/HybridPKEDEM_INDCPA_MultiChal.proof
@@ -1,3 +1,8 @@
+// Proves that the hybrid PKE-DEM (KEM/DEM) construction is IND-CPA multi-challenge secure.
+// Assumes: INDCPA_MultiChal(P) for the public-key scheme and INDOT(E) for the symmetric scheme.
+// Strategy: Swaps the encapsulated key via INDCPA, then swaps the symmetric ciphertext via INDOT,
+// then swaps the encapsulated key back via INDCPA (symmetric three-hop structure).
+
 import '../../Primitives/PubKeyEnc.primitive';
 import '../../Primitives/SymEnc.primitive';
 import '../../Schemes/PubKeyEnc/HybridPKEDEM.scheme';

--- a/Proofs/PubKeyEnc/INDCPA_implies_INDCPA_MultiChal.proof
+++ b/Proofs/PubKeyEnc/INDCPA_implies_INDCPA_MultiChal.proof
@@ -1,3 +1,9 @@
+// Proves that single-challenge IND-CPA security implies multi-challenge IND-CPA security
+// for public-key encryption via a hybrid argument.
+// Assumes: INDCPA(E) and a bound on the number of challenge queries (calls <= q).
+// Strategy: Induction over challenge queries, switching one query at a time from left
+// to right using the single-challenge IND-CPA assumption.
+
 import '../../Primitives/PubKeyEnc.primitive';
 import '../../Primitives/NonNullableSymEnc.primitive';
 import '../../Games/PubKeyEnc/INDCPA_MultiChal.game';

--- a/Proofs/SymEnc/EncryptThenMAC_INDCCA_MultiChal.proof
+++ b/Proofs/SymEnc/EncryptThenMAC_INDCCA_MultiChal.proof
@@ -1,3 +1,8 @@
+// Proves that the Encrypt-then-MAC construction is IND-CCA multi-challenge secure.
+// Assumes: INDCPA_MultiChal(E) and SUFCMA(M).
+// Strategy: Uses SUF-CMA to replace MAC verification with rejection of all non-cached
+// ciphertexts, then swaps left/right via IND-CPA, then restores the MAC.
+
 import '../../Primitives/SymEnc.primitive';
 import '../../Primitives/MAC.primitive';
 import '../../Games/SymEnc/INDCPA_MultiChal.game';

--- a/Proofs/SymEnc/GeneralDoubleSymEnc_INDCPA$_MultiChal.proof
+++ b/Proofs/SymEnc/GeneralDoubleSymEnc_INDCPA$_MultiChal.proof
@@ -1,3 +1,8 @@
+// Proves that general double symmetric encryption is IND-CPA$ multi-challenge secure.
+// Assumes: INDCPA$_MultiChal(E) for the outer encryption scheme.
+// Strategy: Reduces to the outer scheme's INDCPA$ security via a single reduction that
+// encrypts with the inner scheme and delegates the outer encryption to the challenger.
+
 import '../../Primitives/NonNullableSymEnc.primitive';
 import '../../Schemes/SymEnc/GeneralDoubleSymEnc.scheme';
 import '../../Games/SymEnc/INDCPA$_MultiChal.game';

--- a/Proofs/SymEnc/GeneralDoubleSymEnc_INDOT$.proof
+++ b/Proofs/SymEnc/GeneralDoubleSymEnc_INDOT$.proof
@@ -1,3 +1,8 @@
+// Proves that general double symmetric encryption is IND-OT$ secure.
+// Assumes: INDOT$(T) for the outer encryption scheme.
+// Strategy: Reduces to the outer scheme's INDOT$ security by encrypting with the inner
+// scheme and delegating the outer encryption to the challenger.
+
 import '../../Primitives/NonNullableSymEnc.primitive';
 import '../../Schemes/SymEnc/GeneralDoubleSymEnc.scheme';
 import '../../Games/SymEnc/INDOT$.game';

--- a/Proofs/SymEnc/INDCPA$_MultiChal_implies_INDCPA_MultiChal.proof
+++ b/Proofs/SymEnc/INDCPA$_MultiChal_implies_INDCPA_MultiChal.proof
@@ -1,3 +1,9 @@
+// Proves that IND-CPA$ multi-challenge security implies IND-CPA multi-challenge security
+// for symmetric encryption.
+// Assumes: INDCPA$_MultiChal(E).
+// Strategy: Two reductions route the left and right messages through the INDCPA$ challenger;
+// the random ciphertext bridge in the middle connects them via the assumption.
+
 import '../../Primitives/SymEnc.primitive';
 import '../../Games/SymEnc/INDCPA_MultiChal.game';
 import '../../Games/SymEnc/INDCPA$_MultiChal.game';

--- a/Proofs/SymEnc/INDOT$_implies_DoubleSymEnc_INDOT$.proof
+++ b/Proofs/SymEnc/INDOT$_implies_DoubleSymEnc_INDOT$.proof
@@ -1,3 +1,8 @@
+// Proves that double symmetric encryption (same scheme applied twice) is IND-OT$ secure.
+// Assumes: INDOT$(E) for the underlying encryption scheme.
+// Strategy: Reduces to INDOT$ of the underlying scheme by encrypting once and delegating
+// the second encryption to the challenger.
+
 import '../../Primitives/NonNullableSymEnc.primitive';
 import '../../Schemes/SymEnc/DoubleSymEnc.scheme';
 import '../../Games/SymEnc/INDOT$.game';

--- a/Proofs/SymEnc/INDOT$_implies_INDOT.proof
+++ b/Proofs/SymEnc/INDOT$_implies_INDOT.proof
@@ -1,3 +1,9 @@
+// Proves that IND-OT$ (one-time real-or-random) security implies IND-OT (one-time
+// left-or-right) security for symmetric encryption.
+// Assumes: INDOT$(E).
+// Strategy: Two reductions route the left and right messages through the INDOT$ challenger;
+// the random ciphertext bridge in the middle connects them via the assumption.
+
 import '../../Primitives/SymEnc.primitive';
 import '../../Games/SymEnc/INDOT.game';
 import '../../Games/SymEnc/INDOT$.game';

--- a/Schemes/KEM/KEMPRF.scheme
+++ b/Schemes/KEM/KEMPRF.scheme
@@ -1,3 +1,5 @@
+// KEM that applies a PRF to the shared secret of an underlying KEM, keyed by the
+// shared secret and evaluated on the ciphertext, to derive a new shared secret.
 import '../../Primitives/KEM.primitive';
 import '../../Primitives/PRF.primitive';
 

--- a/Schemes/PRG/CounterPRG.scheme
+++ b/Schemes/PRG/CounterPRG.scheme
@@ -1,3 +1,4 @@
+// PRG built from a PRF using counter mode: evaluates F(s, 0) || F(s, 1).
 import '../../Primitives/PRG.primitive';
 import '../../Primitives/PRF.primitive';
 

--- a/Schemes/PRG/TriplingPRG.scheme
+++ b/Schemes/PRG/TriplingPRG.scheme
@@ -1,3 +1,5 @@
+// PRG with tripled stretch: applies a length-doubling PRG twice to produce 3x output.
+// Splits G(s) into (x, y), then outputs x || G(y).
 import '../../Primitives/PRG.primitive';
 
 Scheme TriplingPRG(PRG G) extends PRG {

--- a/Schemes/PubKeyEnc/ElGamal.scheme
+++ b/Schemes/PubKeyEnc/ElGamal.scheme
@@ -1,3 +1,5 @@
+// ElGamal public-key encryption over a cyclic group G.
+// Encrypts by computing (g^r, m * pk^r); decrypts by dividing out c[0]^sk.
 import '../../Primitives/PubKeyEnc.primitive';
 
 Scheme ElGamal(Group G) extends PubKeyEnc {

--- a/Schemes/PubKeyEnc/HybridPKEDEM.scheme
+++ b/Schemes/PubKeyEnc/HybridPKEDEM.scheme
@@ -1,3 +1,5 @@
+// Hybrid public-key encryption (KEM-DEM paradigm): encrypts a fresh symmetric key
+// under the public-key scheme, then encrypts the message with that symmetric key.
 import '../../Primitives/SymEnc.primitive';
 import '../../Primitives/PubKeyEnc.primitive';
 

--- a/Schemes/SymEnc/DoubleSymEnc.scheme
+++ b/Schemes/SymEnc/DoubleSymEnc.scheme
@@ -1,3 +1,4 @@
+// Double encryption using the same symmetric encryption scheme with two independent keys.
 import '../../Primitives/NonNullableSymEnc.primitive';
 
 Scheme DoubleSymEnc(SymEnc s) extends SymEnc {

--- a/Schemes/SymEnc/EncryptThenMAC.scheme
+++ b/Schemes/SymEnc/EncryptThenMAC.scheme
@@ -1,7 +1,8 @@
+// Encrypt-then-MAC: composes a symmetric encryption scheme with a MAC for authenticated
+// encryption. Encrypts the message, then MACs the ciphertext; decryption verifies the tag first.
 import '../../Primitives/SymEnc.primitive';
 import '../../Primitives/MAC.primitive';
 
-// Specify some precondition that E.Ciphertext subsets M.Message
 Scheme EncryptThenMAC(SymEnc E, MAC M) extends SymEnc {
     requires E.Ciphertext subsets M.Message;
 

--- a/Schemes/SymEnc/GeneralDoubleSymEnc.scheme
+++ b/Schemes/SymEnc/GeneralDoubleSymEnc.scheme
@@ -1,3 +1,4 @@
+// Double encryption with two different symmetric encryption schemes: encrypts with S then T.
 import '../../Primitives/NonNullableSymEnc.primitive';
 
 Scheme GeneralDoubleSymEnc(SymEnc S, SymEnc T) extends SymEnc {

--- a/Schemes/SymEnc/ModOTP.scheme
+++ b/Schemes/SymEnc/ModOTP.scheme
@@ -1,3 +1,4 @@
+// Modular one-time pad: symmetric encryption over ModInt<q> using addition mod q.
 import '../../Primitives/SymEnc.primitive';
 
 Scheme ModOTP(Int q) extends SymEnc {

--- a/Schemes/SymEnc/OTP.scheme
+++ b/Schemes/SymEnc/OTP.scheme
@@ -1,3 +1,4 @@
+// One-time pad: symmetric encryption over BitString<lambda> using XOR.
 import '../../Primitives/SymEnc.primitive';
 
 Scheme OTP(Int lambda) extends SymEnc {

--- a/applications/KEMCombiner-GHP18/TwoKeyPRF.primitive
+++ b/applications/KEMCombiner-GHP18/TwoKeyPRF.primitive
@@ -1,3 +1,5 @@
+// Two-key Pseudorandom Function (PRF) primitive for KEM combiner constructions.
+// Provides a deterministic evaluate operation that takes two independent keys and an input.
 Primitive TwoKeyPRF(Int lambda1, Int lambda2, Int in, Int out) {
     Int lambda1 = lambda1;
     Int lambda2 = lambda2;

--- a/joy/Primitives/SymEnc.primitive
+++ b/joy/Primitives/SymEnc.primitive
@@ -1,3 +1,5 @@
+// Symmetric encryption primitive (Joy of Cryptography version).
+// Provides KeyGen, Enc, and deterministic Dec (returns Message?, allowing decryption failure).
 Primitive SymEnc(Set MessageSpace, Set CiphertextSpace, Set KeySpace) {
     Set Message = MessageSpace;
     Set Ciphertext = CiphertextSpace;

--- a/joy_old/2/2_12_DoubleOTP.scheme
+++ b/joy_old/2/2_12_DoubleOTP.scheme
@@ -1,3 +1,5 @@
+// Chapter 2, Construction 2.12: Double OTP encryption scheme.
+// Encrypts by XORing the message with two independent key halves in sequence.
 import '../../Primitives/SymEnc.primitive';
 
 Scheme DoubleOTP(Int lambda) extends SymEnc {

--- a/joy_old/2_Exercises/2_13.proof
+++ b/joy_old/2_Exercises/2_13.proof
@@ -1,3 +1,6 @@
+// Exercise 2.13: SymEncSquared has one-time indistinguishability (INDOT),
+// assuming the underlying scheme E has INDOT. Reduces via a single reduction
+// that forwards two independent eavesdrop calls to E's INDOT challenger.
 import '../../Primitives/SymEnc.primitive';
 import '../../joy_old/2_Exercises/2_13_SymEncSquared.scheme';
 import '../../Games/SymEnc/INDOT.game';

--- a/joy_old/2_Exercises/2_13_SymEncSquared.scheme
+++ b/joy_old/2_Exercises/2_13_SymEncSquared.scheme
@@ -1,3 +1,5 @@
+// Exercise 2.13: "Squared" encryption scheme that encrypts the same message
+// twice under two independent keys, returning a pair of ciphertexts.
 import '../../Primitives/SymEnc.primitive';
 
 Scheme SymEncSquared(SymEnc E) extends SymEnc {

--- a/joy_old/2_Exercises/2_14.game
+++ b/joy_old/2_Exercises/2_14.game
@@ -1,3 +1,5 @@
+// Exercise 2.14: One-time secrecy variant where the adversary submits a single
+// message and must distinguish its encryption from an encryption of a random message.
 import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {

--- a/joy_old/2_Exercises/2_14_Backward.proof
+++ b/joy_old/2_Exercises/2_14_Backward.proof
@@ -1,3 +1,5 @@
+// Exercise 2.14 (backward direction): The Foo security game implies INDOT.
+// Uses two reductions that swap which message argument is forwarded to Foo.
 import '../../Primitives/SymEnc.primitive';
 import '../../joy_old/2_Exercises/2_14.game';
 import '../../Games/SymEnc/INDOT.game';

--- a/joy_old/2_Exercises/2_14_Forward.proof
+++ b/joy_old/2_Exercises/2_14_Forward.proof
@@ -1,3 +1,5 @@
+// Exercise 2.14 (forward direction): INDOT implies the Foo security game.
+// Reduces by sampling a random message and forwarding to INDOT's Eavesdrop oracle.
 import '../../Primitives/SymEnc.primitive';
 import '../../joy_old/2_Exercises/2_14.game';
 import '../../Games/SymEnc/INDOT.game';

--- a/joy_old/2_Exercises/2_15.game
+++ b/joy_old/2_Exercises/2_15.game
@@ -1,3 +1,5 @@
+// Exercise 2.15: Security game where the adversary submits two messages (mL, mR)
+// and receives two ciphertexts; Left encrypts (mL, mR), Right encrypts (mR, mL).
 import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {

--- a/joy_old/2_Exercises/2_15_Backward.proof
+++ b/joy_old/2_Exercises/2_15_Backward.proof
@@ -1,3 +1,5 @@
+// Exercise 2.15 (backward direction): The Foo security game (swap two ciphertexts)
+// implies INDOT. Reduces by extracting one ciphertext from the Foo pair.
 import '../../Primitives/SymEnc.primitive';
 import '../../joy_old/2_Exercises/2_15.game';
 import '../../Games/SymEnc/INDOT.game';

--- a/joy_old/2_Exercises/2_15_Forward.proof
+++ b/joy_old/2_Exercises/2_15_Forward.proof
@@ -1,3 +1,5 @@
+// Exercise 2.15 (forward direction): INDOT implies the Foo security game.
+// Reduces by making two INDOT eavesdrop calls with swapped argument order.
 import '../../Primitives/SymEnc.primitive';
 import '../../joy_old/2_Exercises/2_15.game';
 import '../../Games/SymEnc/INDOT.game';

--- a/joy_old/5/5_2_PseudoOTP.scheme
+++ b/joy_old/5/5_2_PseudoOTP.scheme
@@ -1,3 +1,5 @@
+// Chapter 5, Construction 5.2: Pseudo-OTP encryption scheme.
+// Uses a PRG to stretch a short key and XORs the result with the message.
 import '../../Primitives/SymEnc.primitive';
 import '../../Primitives/PRG.primitive';
 

--- a/joy_old/5_Exercises/5_10.proof
+++ b/joy_old/5_Exercises/5_10.proof
@@ -1,3 +1,5 @@
+// Exercise 5.10: PRG_5_10 is a secure PRG with doubled stretch, assuming G is secure.
+// Three-stage hybrid: replace G(s) with random, use OTP security on x+y, then replace G(y).
 import '../../Primitives/PRG.primitive';
 import '../../joy_old/5_Exercises/5_10.scheme';
 import '../../Schemes/SymEnc/OTP.scheme';

--- a/joy_old/5_Exercises/5_10.scheme
+++ b/joy_old/5_Exercises/5_10.scheme
@@ -1,3 +1,5 @@
+// Exercise 5.10: PRG with doubled stretch constructed from a length-doubling PRG.
+// Computes G(s)=(x||y), then outputs (x+y) || G(y).
 import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_10(PRG G) extends PRG {

--- a/joy_old/5_Exercises/5_8_PseudoOTP_OTUC.proof
+++ b/joy_old/5_Exercises/5_8_PseudoOTP_OTUC.proof
@@ -1,3 +1,5 @@
+// Exercise 5.8 helper: PseudoOTP has one-time uniform ciphertext security (INDOT$).
+// Assumes PRG security of G and INDOT$ of OTP. Used by the 5.8(e) and 5.8(f) proofs.
 import '../../Primitives/PRG.primitive';
 import '../../joy_old/5/5_2_PseudoOTP.scheme';
 import '../../Games/SymEnc/INDOT$.game';

--- a/joy_old/5_Exercises/5_8_a.proof
+++ b/joy_old/5_Exercises/5_8_a.proof
@@ -1,3 +1,5 @@
+// Exercise 5.8(a): PRG_5_8_a is a secure PRG, assuming G is a secure PRG.
+// Hybrid argument: first replace G(s) with random, then replace G(x) and G(z) with random.
 import '../../Primitives/PRG.primitive';
 import '../../joy_old/5_Exercises/5_8_a.scheme';
 import '../../Games/PRG/PRGSecurity.game';

--- a/joy_old/5_Exercises/5_8_a.scheme
+++ b/joy_old/5_Exercises/5_8_a.scheme
@@ -1,3 +1,5 @@
+// Exercise 5.8(a): PRG construction with stretch 5*lambda.
+// Applies G (with stretch 2*lambda) to seed, then applies G again to the first and third output blocks.
 import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_8_a(PRG G) extends PRG {

--- a/joy_old/5_Exercises/5_8_b.proof
+++ b/joy_old/5_Exercises/5_8_b.proof
@@ -1,3 +1,5 @@
+// Exercise 5.8(b): PRG_5_8_b is a secure PRG, assuming G is a secure PRG.
+// Single reduction: replace G(s) with random and truncate to the first two blocks.
 import '../../Primitives/PRG.primitive';
 import '../../joy_old/5_Exercises/5_8_b.scheme';
 import '../../Games/PRG/PRGSecurity.game';

--- a/joy_old/5_Exercises/5_8_b.scheme
+++ b/joy_old/5_Exercises/5_8_b.scheme
@@ -1,3 +1,5 @@
+// Exercise 5.8(b): PRG construction with stretch lambda.
+// Applies G (with stretch 2*lambda) to seed and outputs only the first two blocks.
 import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_8_b(PRG G) extends PRG {

--- a/joy_old/5_Exercises/5_8_e.proof
+++ b/joy_old/5_Exercises/5_8_e.proof
@@ -1,3 +1,5 @@
+// Exercise 5.8(e): PRG_5_8_e (G(s) XOR G(0^lambda)) is a secure PRG.
+// Assumes G is a secure PRG and PseudoOTP has one-time uniform ciphertext security.
 import '../../Primitives/PRG.primitive';
 import '../../joy_old/5_Exercises/5_8_e.scheme';
 import '../../joy_old/5/5_2_PseudoOTP.scheme';

--- a/joy_old/5_Exercises/5_8_e.scheme
+++ b/joy_old/5_Exercises/5_8_e.scheme
@@ -1,3 +1,4 @@
+// Exercise 5.8(e): PRG construction that XORs G(s) with the constant G(0^lambda).
 import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_8_e(PRG G) extends PRG {

--- a/joy_old/5_Exercises/5_8_f.proof
+++ b/joy_old/5_Exercises/5_8_f.proof
@@ -1,3 +1,5 @@
+// Exercise 5.8(f): PRG_5_8_f (G(sL) XOR G(sR)) is a secure PRG.
+// Assumes G is a secure PRG and PseudoOTP has one-time uniform ciphertext security.
 import '../../Primitives/PRG.primitive';
 import '../../joy_old/5_Exercises/5_8_f.scheme';
 import '../../joy_old/5/5_2_PseudoOTP.scheme';

--- a/joy_old/5_Exercises/5_8_f.scheme
+++ b/joy_old/5_Exercises/5_8_f.scheme
@@ -1,3 +1,5 @@
+// Exercise 5.8(f): PRG construction with doubled seed length.
+// Splits seed into halves sL and sR, outputs G(sL) XOR G(sR).
 import '../../Primitives/PRG.primitive';
 
 Scheme PRG_5_8_f(PRG G) extends PRG {

--- a/joy_old/7_Exercises/7_13.game
+++ b/joy_old/7_Exercises/7_13.game
@@ -1,3 +1,5 @@
+// Exercise 7.13: CPA-style single-message secrecy game with a persistent key.
+// Left encrypts the real message; Right encrypts a random message.
 import '../../Primitives/SymEnc.primitive';
 
 Game Left(SymEnc E) {

--- a/joy_old/7_Exercises/7_13_Backward.proof
+++ b/joy_old/7_Exercises/7_13_Backward.proof
@@ -1,3 +1,5 @@
+// Exercise 7.13 (backward direction): The Challenge game implies IND-CPA (multi-challenge).
+// Uses two reductions that swap which message argument is forwarded to Challenge.
 import '../../Primitives/SymEnc.primitive';
 import '../../joy_old/7_Exercises/7_13.game';
 import '../../Games/SymEnc/INDCPA_MultiChal.game';

--- a/joy_old/7_Exercises/7_13_Forward.proof
+++ b/joy_old/7_Exercises/7_13_Forward.proof
@@ -1,3 +1,5 @@
+// Exercise 7.13 (forward direction): IND-CPA (multi-challenge) implies the Challenge game.
+// Reduces by sampling a random message and forwarding to the IND-CPA eavesdrop oracle.
 import '../../Primitives/SymEnc.primitive';
 import '../../joy_old/7_Exercises/7_13.game';
 import '../../Games/SymEnc/INDCPA_MultiChal.game';

--- a/joy_old/9_Exercises/9_6_CCA$impliesCCA.proof
+++ b/joy_old/9_Exercises/9_6_CCA$impliesCCA.proof
@@ -1,3 +1,5 @@
+// Exercise 9.6: IND-CCA$ (multi-challenge) implies IND-CCA (multi-challenge).
+// Two reductions forward mL or mR to the CTXT oracle, with a swap in the middle.
 import '../../Primitives/SymEnc.primitive';
 import '../../Games/SymEnc/INDCCA_MultiChal.game';
 import '../../Games/SymEnc/INDCCA$_MultiChal.game';


### PR DESCRIPTION
Add top-of-file comments explaining what each file contains across all example primitives, schemes, games, and proofs that were missing them. Enhance minimal reference-only comments in SymEnc and PubKeyEnc games with descriptions of the actual game structure. Rename the "Fake" game to "Ideal" in PubKeyEnc/Correctness and SymEnc/Correctness to match the convention used in PRP/Correctness.