### PR TITLE
Adopt tuple-destructuring bindings across the examples

### DIFF
--- a/Games/KEM/Correctness.game
+++ b/Games/KEM/Correctness.game
@@ -10,9 +10,7 @@ import '../../Primitives/KEM.primitive';
 
 Game FromDecaps(KEM K) {
     [K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute(K.PublicKey pk, K.SecretKey sk) {
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(pk);
-        K.SharedSecret ss_e = encaps_result[0];
-        K.Ciphertext ct = encaps_result[1];
+        [K.SharedSecret, K.Ciphertext] [ss_e, ct] = K.Encaps(pk);
         K.SharedSecret ss_d = K.Decaps(sk, ct);
         return [ct, ss_e, ss_d];
     }
@@ -20,9 +18,7 @@ Game FromDecaps(KEM K) {
 
 Game FromEncaps(KEM K) {
     [K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute(K.PublicKey pk, K.SecretKey sk) {
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(pk);
-        K.Ciphertext ct = encaps_result[1];
-        K.SharedSecret ss = encaps_result[0];
+        [K.SharedSecret, K.Ciphertext] [ss, ct] = K.Encaps(pk);
         return [ct, ss, ss];
     }
 }

--- a/Games/KEM/INDCCA_MultiChal.game
+++ b/Games/KEM/INDCCA_MultiChal.game
@@ -12,11 +12,9 @@ Game Real(KEM K) {
     K.Ciphertext ctStar;
 
     [K.PublicKey, K.SharedSecret, K.Ciphertext] Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        sk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
-        ctStar = rsp[1];
-        return [k[0], rsp[0], rsp[1]];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ctStar] = K.Encaps(pk);
+        return [pk, ss, ctStar];
     }
 
     K.SharedSecret? Decaps(K.Ciphertext c) {
@@ -32,12 +30,10 @@ Game Random(KEM K) {
     K.Ciphertext ctStar;
 
     [K.PublicKey, K.SharedSecret, K.Ciphertext] Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        sk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ssReal, ctStar] = K.Encaps(pk);
         K.SharedSecret ss <- K.SharedSecret;
-        ctStar = rsp[1];
-        return [k[0], ss, rsp[1]];
+        return [pk, ss, ctStar];
     }
 
     K.SharedSecret? Decaps(K.Ciphertext c) {

--- a/Games/KEM/INDCCA_MultiChal_ROM.game
+++ b/Games/KEM/INDCCA_MultiChal_ROM.game
@@ -13,11 +13,9 @@ Game Real(KEM K, Set D, Set R, Function<D, R> H) {
     K.Ciphertext ctStar;
 
     [K.PublicKey, K.SharedSecret, K.Ciphertext] Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        sk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
-        ctStar = rsp[1];
-        return [k[0], rsp[0], rsp[1]];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ctStar] = K.Encaps(pk);
+        return [pk, ss, ctStar];
     }
 
     R Hash(D m) {
@@ -37,12 +35,10 @@ Game Random(KEM K, Set D, Set R, Function<D, R> H) {
     K.Ciphertext ctStar;
 
     [K.PublicKey, K.SharedSecret, K.Ciphertext] Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        sk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss_unused, ctStar] = K.Encaps(pk);
         K.SharedSecret ss <- K.SharedSecret;
-        ctStar = rsp[1];
-        return [k[0], ss, rsp[1]];
+        return [pk, ss, ctStar];
     }
 
     R Hash(D m) {

--- a/Games/KEM/INDCPA_MultiChal.game
+++ b/Games/KEM/INDCPA_MultiChal.game
@@ -12,16 +12,12 @@ Game Real(KEM K) {
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
         return pk;
     }
 
     [K.SharedSecret, K.Ciphertext] Challenge() {
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(pk);
-        K.SharedSecret ss = rsp[0];
-        K.Ciphertext ctxt = rsp[1];
+        [K.SharedSecret, K.Ciphertext] [ss, ctxt] = K.Encaps(pk);
         return [ss, ctxt];
     }
 }
@@ -31,9 +27,7 @@ Game Random(KEM K) {
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
         return pk;
     }
 

--- a/Games/PubKeyEnc/INDCPA$_MultiChal.game
+++ b/Games/PubKeyEnc/INDCPA$_MultiChal.game
@@ -8,9 +8,7 @@ Game Real(PubKeyEnc E) {
     E.SecretKey sk;
 
     E.PublicKey Initialize() {
-        [E.PublicKey, E.SecretKey] k = E.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
         return pk;
     }
 
@@ -24,9 +22,7 @@ Game Random(PubKeyEnc E) {
     E.SecretKey sk;
 
     E.PublicKey Initialize() {
-        [E.PublicKey, E.SecretKey] k = E.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
         return pk;
     }
 

--- a/Games/PubKeyEnc/INDCPA.game
+++ b/Games/PubKeyEnc/INDCPA.game
@@ -9,9 +9,7 @@ Game Left(PubKeyEnc E) {
     Int count;
 
     E.PublicKey Initialize() {
-        [E.PublicKey, E.SecretKey] k = E.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
         count = 0;
         return pk;
     }
@@ -32,9 +30,7 @@ Game Right(PubKeyEnc E) {
     Int count;
 
     E.PublicKey Initialize() {
-        [E.PublicKey, E.SecretKey] k = E.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
         count = 0;
         return pk;
     }

--- a/Games/PubKeyEnc/INDCPA_MultiChal.game
+++ b/Games/PubKeyEnc/INDCPA_MultiChal.game
@@ -8,9 +8,7 @@ Game Left(PubKeyEnc E) {
     E.SecretKey sk;
 
     E.PublicKey Initialize() {
-        [E.PublicKey, E.SecretKey] k = E.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
         return pk;
     }
 
@@ -24,9 +22,7 @@ Game Right(PubKeyEnc E) {
     E.SecretKey sk;
 
     E.PublicKey Initialize() {
-        [E.PublicKey, E.SecretKey] k = E.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
         return pk;
     }
 

--- a/Proofs/Group/CDH_implies_HashedDDH.proof
+++ b/Proofs/Group/CDH_implies_HashedDDH.proof
@@ -67,8 +67,8 @@ Reduction R_CDH(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose 
 
     [GroupElem<G>, GroupElem<G>, BitString<n>] Initialize() {
         u <- BitString<n>;
-        [GroupElem<G>, GroupElem<G>] pair = challenger.Initialize();
-        return [pair[0], pair[1], u];
+        [GroupElem<G>, GroupElem<G>] [x, y] = challenger.Initialize();
+        return [x, y, u];
     }
 
     BitString<n> Hash(GroupElem<G> x) {

--- a/Proofs/Group/DDHMultiChal_implies_HashedDDHMultiChal.proof
+++ b/Proofs/Group/DDHMultiChal_implies_HashedDDHMultiChal.proof
@@ -54,8 +54,8 @@ Reduction R_DDH(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose 
     }
 
     [GroupElem<G>, BitString<n>] Challenge() {
-        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
-        return [pair[0], H(pair[1])];
+        [GroupElem<G>, GroupElem<G>] [x, y] = challenger.Challenge();
+        return [x, H(y)];
     }
 }
 

--- a/Proofs/Group/DDH_implies_CDH.proof
+++ b/Proofs/Group/DDH_implies_CDH.proof
@@ -53,9 +53,8 @@ Reduction R(Group G) compose DDH(G) against CDH(G).Adversary {
     GroupElem<G> z;
 
     [GroupElem<G>, GroupElem<G>] Initialize() {
-        [GroupElem<G>, GroupElem<G>, GroupElem<G>] triple = challenger.Initialize();
-        z = triple[2];
-        return [triple[0], triple[1]];
+        [GroupElem<G>, GroupElem<G>, GroupElem<G>] [x, y, z] = challenger.Initialize();
+        return [x, y];
     }
 
     Bool Solve(GroupElem<G> c) {

--- a/Proofs/Group/DDH_implies_HashedDDH.proof
+++ b/Proofs/Group/DDH_implies_HashedDDH.proof
@@ -51,8 +51,8 @@ games:
 // pair.
 Reduction R(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose DDH(G) against HashedDDH(G, n, H).Adversary {
     [GroupElem<G>, GroupElem<G>, BitString<n>] Initialize() {
-        [GroupElem<G>, GroupElem<G>, GroupElem<G>] triple = challenger.Initialize();
-        return [triple[0], triple[1], H(triple[2])];
+        [GroupElem<G>, GroupElem<G>, GroupElem<G>] [x, y, z] = challenger.Initialize();
+        return [x, y, H(z)];
     }
 
     BitString<n> Hash(GroupElem<G> x) {

--- a/Proofs/KEM/HashedElGamalKEM_INDCCA.proof
+++ b/Proofs/KEM/HashedElGamalKEM_INDCCA.proof
@@ -107,9 +107,7 @@ Reduction R_Gap(Group G, Int n, Function<GroupElem<G>, BitString<n>> H)
     Map<GroupElem<G>, BitString<n>> PendingDecaps;
 
     [GroupElem<G>, BitString<n>, GroupElem<G>] Initialize() {
-        [GroupElem<G>, GroupElem<G>] init = challenger.Initialize();
-        pk = init[0];
-        ctStar = init[1];
+        [GroupElem<G>, GroupElem<G>] [pk, ctStar] = challenger.Initialize();
         ssStar <- BitString<n>;
         return [pk, ssStar, ctStar];
     }

--- a/Proofs/KEM/KEMPRF_Correctness.proof
+++ b/Proofs/KEM/KEMPRF_Correctness.proof
@@ -48,10 +48,7 @@ games:
 // and applies F.evaluate to both shared secrets.
 Reduction R_KEM(KEM K, PRF F, KEMPRF KF) compose KEMCorrectness(K) against KEMCorrectness(KF).Adversary {
     [KF.Ciphertext, KF.SharedSecret, KF.SharedSecret] Compute(KF.PublicKey pk, KF.SecretKey sk) {
-        [K.Ciphertext, K.SharedSecret, K.SharedSecret] result = challenger.Compute(pk, sk);
-        K.Ciphertext ct = result[0];
-        K.SharedSecret ss_e = result[1];
-        K.SharedSecret ss_d = result[2];
+        [K.Ciphertext, K.SharedSecret, K.SharedSecret] [ct, ss_e, ss_d] = challenger.Compute(pk, sk);
         return [ct, F.evaluate(ss_e, ct), F.evaluate(ss_d, ct)];
     }
 }

--- a/Proofs/KEM/KEMPRF_INDCCA.proof
+++ b/Proofs/KEM/KEMPRF_INDCCA.proof
@@ -47,11 +47,9 @@ Reduction R_KEM(KEM K, PRF F, KEMPRF KF) compose KEM_INDCCA_MultiChal(K) against
     KF.Ciphertext ctStar;
 
     [KF.PublicKey, KF.SharedSecret, KF.Ciphertext] Initialize() {
-        [K.PublicKey, K.SharedSecret, K.Ciphertext] rsp = challenger.Initialize();
-        K.SharedSecret ss = rsp[1];
-        K.Ciphertext ct = rsp[2];
+        [K.PublicKey, K.SharedSecret, K.Ciphertext] [pk, ss, ct] = challenger.Initialize();
         ctStar = ct;
-        return [rsp[0], F.evaluate(ss, ct), ct];
+        return [pk, F.evaluate(ss, ct), ct];
     }
 
     KF.SharedSecret? Decaps(KF.Ciphertext c) {
@@ -73,12 +71,11 @@ Game G_RandKey(KEM K, PRF F) {
     K.Ciphertext ctStar;
 
     [K.PublicKey, BitString<F.out>, K.Ciphertext] Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        sk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(pk);
         BitString<F.lambda> key <- BitString<F.lambda>;
         ctStar = rsp[1];
-        return [k[0], F.evaluate(key, rsp[1]), rsp[1]];
+        return [pk, F.evaluate(key, rsp[1]), rsp[1]];
     }
 
     BitString<F.out>? Decaps(K.Ciphertext c) {
@@ -96,12 +93,11 @@ Reduction R_MultiPRF(KEM K, PRF F, KEMPRF KF) compose PRFSecurity_MultiKey(F) ag
     K.Ciphertext ctStar;
 
     [KF.PublicKey, KF.SharedSecret, KF.Ciphertext] Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        sk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(pk);
         ctStar = rsp[1];
         BitString<F.out> ss = challenger.Lookup(rsp[1]);
-        return [k[0], ss, rsp[1]];
+        return [pk, ss, rsp[1]];
     }
 
     KF.SharedSecret? Decaps(KF.Ciphertext c) {

--- a/Proofs/KEM/KEMPRF_INDCPA.proof
+++ b/Proofs/KEM/KEMPRF_INDCPA.proof
@@ -62,9 +62,7 @@ Reduction R_KEM(KEM K, PRF F, KEMPRF KF) compose KEM_INDCPA_MultiChal(K) against
     }
 
     [KF.SharedSecret, KF.Ciphertext] Challenge() {
-        [K.SharedSecret, K.Ciphertext] rsp = challenger.Challenge();
-        K.SharedSecret ss = rsp[0];
-        K.Ciphertext ct = rsp[1];
+        [K.SharedSecret, K.Ciphertext] [ss, ct] = challenger.Challenge();
         return [F.evaluate(ss, ct), ct];
     }
 }

--- a/Proofs/PubKeyEnc/ElGamal_INDCPA_MultiChal.proof
+++ b/Proofs/PubKeyEnc/ElGamal_INDCPA_MultiChal.proof
@@ -51,8 +51,8 @@ Reduction R_L(Group G) compose DDHMultiChal(G) against INDCPA_MultiChal(ElGamal(
     }
 
     [GroupElem<G>, GroupElem<G>] Challenge(GroupElem<G> mL, GroupElem<G> mR) {
-        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
-        return [pair[0], mL * pair[1]];
+        [GroupElem<G>, GroupElem<G>] [x, y] = challenger.Challenge();
+        return [x, mL * y];
     }
 }
 
@@ -63,7 +63,7 @@ Reduction R_R(Group G) compose DDHMultiChal(G) against INDCPA_MultiChal(ElGamal(
     }
 
     [GroupElem<G>, GroupElem<G>] Challenge(GroupElem<G> mL, GroupElem<G> mR) {
-        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
-        return [pair[0], mR * pair[1]];
+        [GroupElem<G>, GroupElem<G>] [x, y] = challenger.Challenge();
+        return [x, mR * y];
     }
 }

--- a/Proofs/PubKeyEnc/HashedElGamal_INDCPA_MultiChal.proof
+++ b/Proofs/PubKeyEnc/HashedElGamal_INDCPA_MultiChal.proof
@@ -54,8 +54,8 @@ Reduction R_L(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose Ha
     }
 
     [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
-        [GroupElem<G>, BitString<n>] pair = challenger.Challenge();
-        return [pair[0], pair[1] + mL];
+        [GroupElem<G>, BitString<n>] [groupElem, bitString] = challenger.Challenge();
+        return [groupElem, bitString + mL];
     }
 }
 
@@ -66,7 +66,7 @@ Reduction R_R(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose Ha
     }
 
     [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
-        [GroupElem<G>, BitString<n>] pair = challenger.Challenge();
-        return [pair[0], pair[1] + mR];
+        [GroupElem<G>, BitString<n>] [groupElem, bitString] = challenger.Challenge();
+        return [groupElem, bitString + mR];
     }
 }

--- a/Proofs/PubKeyEnc/HashedElGamal_INDCPA_ROM_MultiChal.proof
+++ b/Proofs/PubKeyEnc/HashedElGamal_INDCPA_ROM_MultiChal.proof
@@ -69,9 +69,9 @@ Reduction R_L(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose DD
     }
 
     [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
-        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
-        BitString<n> h = H(pair[1]);
-        return [pair[0], h + mL];
+        [GroupElem<G>, GroupElem<G>] [x, y] = challenger.Challenge();
+        BitString<n> h = H(y);
+        return [x, h + mL];
     }
 }
 
@@ -86,9 +86,9 @@ Reduction R_R(Group G, Int n, Function<GroupElem<G>, BitString<n>> H) compose DD
     }
 
     [GroupElem<G>, BitString<n>] Challenge(BitString<n> mL, BitString<n> mR) {
-        [GroupElem<G>, GroupElem<G>] pair = challenger.Challenge();
-        BitString<n> h = H(pair[1]);
-        return [pair[0], h + mR];
+        [GroupElem<G>, GroupElem<G>] [x, y] = challenger.Challenge();
+        BitString<n> h = H(y);
+        return [x, h + mR];
     }
 }
 

--- a/Proofs/PubKeyEnc/HybridKEMDEM_INDCPA_MultiChal.proof
+++ b/Proofs/PubKeyEnc/HybridKEMDEM_INDCPA_MultiChal.proof
@@ -99,9 +99,7 @@ games:
 //   from the KEM KEM_INDCPA_MultiChal challenger, which is either real (= Game 0) or random (= Game 1).
 Reduction R1(SymEnc E, KEM K, KEMDEM KD) compose KEM_INDCPA_MultiChal(K) against INDCPA_MultiChal(KD).Adversary {
     KD.Ciphertext Challenge(KD.Message mL, KD.Message mR) {
-        [K.SharedSecret, K.Ciphertext] y = challenger.Challenge();
-        K.SharedSecret k_sym = y[0];
-        K.Ciphertext c_kem = y[1];
+        [K.SharedSecret, K.Ciphertext] [k_sym, c_kem] = challenger.Challenge();
         E.Ciphertext c_sym = E.Enc(k_sym, mL);
         return [c_kem, c_sym];
     }
@@ -116,9 +114,7 @@ Reduction R2(SymEnc E, KEM K, KEMDEM KD) compose KeyUniformity(E) against INDCPA
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
         return pk;
     }
 
@@ -139,9 +135,7 @@ Reduction R3(SymEnc E, KEM K, KEMDEM KD) compose INDOT(E) against INDCPA_MultiCh
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
         return pk;
     }
 
@@ -162,9 +156,7 @@ Reduction R4(SymEnc E, KEM K, KEMDEM KD) compose KeyUniformity(E) against INDCPA
     K.SecretKey sk;
 
     K.PublicKey Initialize() {
-        [K.PublicKey, K.SecretKey] k = K.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
         return pk;
     }
 
@@ -182,9 +174,7 @@ Reduction R4(SymEnc E, KEM K, KEMDEM KD) compose KeyUniformity(E) against INDCPA
 //   from the KEM KEM_INDCPA_MultiChal challenger, which is either real (= Game 5) or random (= Game 4).
 Reduction R5(SymEnc E, KEM K, KEMDEM KD) compose KEM_INDCPA_MultiChal(K) against INDCPA_MultiChal(KD).Adversary {
     KD.Ciphertext Challenge(KD.Message mL, KD.Message mR) {
-        [K.SharedSecret, K.Ciphertext] y = challenger.Challenge();
-        K.SharedSecret k_sym = y[0];
-        K.Ciphertext c_kem = y[1];
+        [K.SharedSecret, K.Ciphertext] [k_sym, c_kem] = challenger.Challenge();
         E.Ciphertext c_sym = E.Enc(k_sym, mR);
         return [c_kem, c_sym];
     }

--- a/Proofs/PubKeyEnc/HybridPKEDEM_INDCPA_MultiChal.proof
+++ b/Proofs/PubKeyEnc/HybridPKEDEM_INDCPA_MultiChal.proof
@@ -58,9 +58,7 @@ Game Intermediate1(SymEnc E, PubKeyEnc P, Hybrid H) {
     P.SecretKey sk;
 
     P.PublicKey Initialize() {
-        [P.PublicKey, P.SecretKey] k = P.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [P.PublicKey, P.SecretKey] [pk, sk] = P.KeyGen();
         return pk;
     }
 
@@ -78,9 +76,7 @@ Reduction R2(SymEnc E, PubKeyEnc P, Hybrid H) compose INDOT(E) against INDCPA_Mu
     P.SecretKey sk;
 
     P.PublicKey Initialize() {
-        [P.PublicKey, P.SecretKey] k = P.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [P.PublicKey, P.SecretKey] [pk, sk] = P.KeyGen();
         return pk;
     }
 
@@ -97,9 +93,7 @@ Game Intermediate2(SymEnc E, PubKeyEnc P, Hybrid H) {
     P.SecretKey sk;
 
     P.PublicKey Initialize() {
-        [P.PublicKey, P.SecretKey] k = P.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [P.PublicKey, P.SecretKey] [pk, sk] = P.KeyGen();
         return pk;
     }
 

--- a/applications/KEMCombiner-GHP18/GHP18_Correctness.proof
+++ b/applications/KEMCombiner-GHP18/GHP18_Correctness.proof
@@ -63,10 +63,9 @@ games:
 // handles KEM2 and PRF locally.
 Reduction R_KEM1(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk2len, Int ct2len, KEMCombiner KC) compose KEMCorrectness(KEM1) against KEMCorrectnessKG(KC).Adversary {
     [KC.Ciphertext, KC.SharedSecret, KC.SharedSecret] Compute() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        KEM1.PublicKey pk1 = k1[0];
-        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] [ct1, ss1_e, ss1_d] = challenger.Compute(pk1, k1[1]);
+        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] [ct1, ss1_e, ss1_d] = challenger.Compute(pk1, sk);
         [KEM2.SharedSecret, KEM2.Ciphertext] [ss2_e, ct2] = KEM2.Encaps(pk2);
         KEM2.SharedSecret ss2_d = KEM2.Decaps(sk2, ct2);
         BitString<pk1len> bpk1 = pk1;
@@ -83,11 +82,10 @@ Reduction R_KEM1(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
 Reduction R_KEM2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk2len, Int ct2len, KEMCombiner KC) compose KEMCorrectness(KEM2) against KEMCorrectnessKG(KC).Adversary {
     [KC.Ciphertext, KC.SharedSecret, KC.SharedSecret] Compute() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk] = KEM2.KeyGen();
         KEM1.PublicKey pk1 = k1[0];
-        KEM2.PublicKey pk2 = k2[0];
         [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1] = KEM1.Encaps(pk1);
-        [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] [ct2, ss2_e, ss2_d] = challenger.Compute(pk2, k2[1]);
+        [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] [ct2, ss2_e, ss2_d] = challenger.Compute(pk2, sk);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1;
         BitString<pk2len> bpk2 = pk2;

--- a/applications/KEMCombiner-GHP18/GHP18_Correctness.proof
+++ b/applications/KEMCombiner-GHP18/GHP18_Correctness.proof
@@ -64,17 +64,10 @@ games:
 Reduction R_KEM1(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk2len, Int ct2len, KEMCombiner KC) compose KEMCorrectness(KEM1) against KEMCorrectnessKG(KC).Adversary {
     [KC.Ciphertext, KC.SharedSecret, KC.SharedSecret] Compute() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         KEM1.PublicKey pk1 = k1[0];
-        KEM2.PublicKey pk2 = k2[0];
-        KEM2.SecretKey sk2 = k2[1];
-        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] result1 = challenger.Compute(pk1, k1[1]);
-        KEM1.Ciphertext ct1 = result1[0];
-        KEM1.SharedSecret ss1_e = result1[1];
-        KEM1.SharedSecret ss1_d = result1[2];
-        [KEM2.SharedSecret, KEM2.Ciphertext] r2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2_e = r2[0];
-        KEM2.Ciphertext ct2 = r2[1];
+        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] [ct1, ss1_e, ss1_d] = challenger.Compute(pk1, k1[1]);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2_e, ct2] = KEM2.Encaps(pk2);
         KEM2.SharedSecret ss2_d = KEM2.Decaps(sk2, ct2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1;
@@ -93,13 +86,8 @@ Reduction R_KEM2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
         [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
         KEM1.PublicKey pk1 = k1[0];
         KEM2.PublicKey pk2 = k2[0];
-        [KEM1.SharedSecret, KEM1.Ciphertext] r1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = r1[0];
-        KEM1.Ciphertext ct1 = r1[1];
-        [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] result2 = challenger.Compute(pk2, k2[1]);
-        KEM2.Ciphertext ct2 = result2[0];
-        KEM2.SharedSecret ss2_e = result2[1];
-        KEM2.SharedSecret ss2_d = result2[2];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1] = KEM1.Encaps(pk1);
+        [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] [ct2, ss2_e, ss2_d] = challenger.Compute(pk2, k2[1]);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1;
         BitString<pk2len> bpk2 = pk2;

--- a/applications/KEMCombiner-GHP18/GHP18_INDCCA_First.proof
+++ b/applications/KEMCombiner-GHP18/GHP18_INDCCA_First.proof
@@ -82,19 +82,10 @@ Reduction R_Correct_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, I
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] corr = challenger.Compute(pk1, sk1);
-        ct1Star = corr[0];
-        KEM1.SharedSecret ss1e = corr[1];
-        ss1d = corr[2];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] [ct1Star, ss1e, ss1d] = challenger.Compute(pk1, sk1);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1Star;
         BitString<pk2len> bpk2 = pk2;
@@ -136,12 +127,8 @@ Reduction R_Correct_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, I
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] corr = challenger.Compute(pk1, sk1);
         ct1Star = corr[0];
         ss1d = corr[2];
@@ -183,16 +170,9 @@ Reduction R_KEM1_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = challenger.Initialize();
-        pk1 = rsp1[0];
-        ss1Star = rsp1[1];
-        ct1Star = rsp1[2];
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM1.PublicKey, KEM1.SharedSecret, KEM1.Ciphertext] [pk1, ss1Star, ct1Star] = challenger.Initialize();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1Star;
         BitString<pk2len> bpk2 = pk2;
@@ -237,17 +217,11 @@ Reduction R_PRF_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int p
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1Star;
         BitString<pk2len> bpk2 = pk2;
@@ -288,13 +262,8 @@ Reduction R_KEM1_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = challenger.Initialize();
-        pk1 = rsp1[0];
-        ss1Star = rsp1[1];
-        ct1Star = rsp1[2];
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SharedSecret, KEM1.Ciphertext] [pk1, ss1Star, ct1Star] = challenger.Initialize();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         KC.SharedSecret ss <- KC.SharedSecret;
@@ -336,12 +305,8 @@ Reduction R_PRF_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int p
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
@@ -381,18 +346,10 @@ Game G_StoredSS1(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk1);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1Star;
         BitString<pk2len> bpk2 = pk2;
@@ -433,18 +390,12 @@ Game G_RandKey(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk2l
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
         ss1Star <- BitString<F.lambda1>;
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1Star;
         BitString<pk2len> bpk2 = pk2;
@@ -485,12 +436,8 @@ Game G_RandKey_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
         ss1Star <- BitString<F.lambda1>;
@@ -531,15 +478,9 @@ Game G_StoredSS1_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk1);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<F.out> ss <- BitString<F.out>;

--- a/applications/KEMCombiner-GHP18/GHP18_INDCCA_Second.proof
+++ b/applications/KEMCombiner-GHP18/GHP18_INDCCA_Second.proof
@@ -82,19 +82,10 @@ Reduction R_Correct_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, I
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
-        [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] corr = challenger.Compute(pk2, sk2);
-        ct2Star = corr[0];
-        KEM2.SharedSecret ss2e = corr[1];
-        ss2d = corr[2];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk1);
+        [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] [ct2Star, ss2e, ss2d] = challenger.Compute(pk2, sk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1Star;
         BitString<pk2len> bpk2 = pk2;
@@ -136,12 +127,8 @@ Reduction R_Correct_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, I
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
         [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] corr = challenger.Compute(pk2, sk2);
@@ -183,16 +170,9 @@ Reduction R_KEM2_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = challenger.Initialize();
-        pk2 = rsp2[0];
-        ss2Star = rsp2[1];
-        ct2Star = rsp2[2];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] [pk2, ss2Star, ct2Star] = challenger.Initialize();
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk1);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1Star;
         BitString<pk2len> bpk2 = pk2;
@@ -237,15 +217,9 @@ Reduction R_PRF_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int p
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk1);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<pk1len> bpk1 = pk1;
@@ -288,13 +262,8 @@ Reduction R_KEM2_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = challenger.Initialize();
-        pk2 = rsp2[0];
-        ss2Star = rsp2[1];
-        ct2Star = rsp2[2];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] [pk2, ss2Star, ct2Star] = challenger.Initialize();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
         KC.SharedSecret ss <- KC.SharedSecret;
@@ -336,12 +305,8 @@ Reduction R_PRF_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int p
 
     [[KEM1.PublicKey, KEM2.PublicKey], KC.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
@@ -381,18 +346,10 @@ Game G_StoredSS2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        ss2Star = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk1);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2Star, ct2Star] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1Star;
         BitString<pk2len> bpk2 = pk2;
@@ -433,15 +390,9 @@ Game G_RandKey(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk2l
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk1);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
@@ -485,12 +436,8 @@ Game G_RandKey_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
@@ -531,17 +478,11 @@ Game G_StoredSS2_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk1 = k1[0];
-        sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk1, sk1] = KEM1.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         ct1Star = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        ss2Star = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2Star, ct2Star] = KEM2.Encaps(pk2);
         BitString<F.out> ss <- BitString<F.out>;
         return [[pk1, pk2], ss, [ct1Star, ct2Star]];
     }

--- a/applications/KEMCombiner-GHP18/GHP18_INDCPA_First.proof
+++ b/applications/KEMCombiner-GHP18/GHP18_INDCPA_First.proof
@@ -66,12 +66,8 @@ Reduction R_KEM1(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
     }
 
     [KC.SharedSecret, KC.Ciphertext] Challenge() {
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = challenger.Challenge();
-        KEM1.SharedSecret ss1 = rsp1[0];
-        KEM1.Ciphertext ct1 = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        KEM2.Ciphertext ct2 = rsp2[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1] = challenger.Challenge();
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1;
         BitString<pk2len> bpk2 = pk2;
@@ -99,9 +95,7 @@ Game G1_RandKey(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk2
         BitString<F.lambda1> key1 <- BitString<F.lambda1>;
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         KEM1.Ciphertext ct1 = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        KEM2.Ciphertext ct2 = rsp2[1];
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1;
         BitString<pk2len> bpk2 = pk2;
@@ -129,9 +123,7 @@ Reduction R_PRF1(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
     [KC.SharedSecret, KC.Ciphertext] Challenge() {
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
         KEM1.Ciphertext ct1 = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        KEM2.Ciphertext ct2 = rsp2[1];
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1;
         BitString<pk2len> bpk2 = pk2;

--- a/applications/KEMCombiner-GHP18/GHP18_INDCPA_Second.proof
+++ b/applications/KEMCombiner-GHP18/GHP18_INDCPA_Second.proof
@@ -66,12 +66,8 @@ Reduction R_KEM2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
     }
 
     [KC.SharedSecret, KC.Ciphertext] Challenge() {
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        KEM1.Ciphertext ct1 = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = challenger.Challenge();
-        KEM2.SharedSecret ss2 = rsp2[0];
-        KEM2.Ciphertext ct2 = rsp2[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1] = KEM1.Encaps(pk1);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2] = challenger.Challenge();
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1;
         BitString<pk2len> bpk2 = pk2;
@@ -96,9 +92,7 @@ Game G2_RandKey(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk2
     }
 
     [BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Challenge() {
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        KEM1.Ciphertext ct1 = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1] = KEM1.Encaps(pk1);
         BitString<F.lambda2> key2 <- BitString<F.lambda2>;
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         KEM2.Ciphertext ct2 = rsp2[1];
@@ -127,9 +121,7 @@ Reduction R_PRF2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int pk
     }
 
     [KC.SharedSecret, KC.Ciphertext] Challenge() {
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk1);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        KEM1.Ciphertext ct1 = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1] = KEM1.Encaps(pk1);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         KEM2.Ciphertext ct2 = rsp2[1];
         BitString<pk1len> bpk1 = pk1;

--- a/applications/KEMCombiner-GHP18/KEMCombiner.scheme
+++ b/applications/KEMCombiner-GHP18/KEMCombiner.scheme
@@ -29,12 +29,8 @@ Scheme KEMCombiner(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int pk1len, Int ct1len, Int 
     [SharedSecret, Ciphertext] Encaps(PublicKey pk) {
         KEM1.PublicKey pk1 = pk[0];
         KEM2.PublicKey pk2 = pk[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] r1 = KEM1.Encaps(pk1);
-        [KEM2.SharedSecret, KEM2.Ciphertext] r2 = KEM2.Encaps(pk2);
-        KEM1.SharedSecret ss1 = r1[0];
-        KEM1.Ciphertext ct1 = r1[1];
-        KEM2.SharedSecret ss2 = r2[0];
-        KEM2.Ciphertext ct2 = r2[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1] = KEM1.Encaps(pk1);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2] = KEM2.Encaps(pk2);
         BitString<pk1len> bpk1 = pk1;
         BitString<ct1len> bct1 = ct1;
         BitString<pk2len> bpk2 = pk2;

--- a/applications/KEMCombiner-GHP18/KEMCorrectnessKG.game
+++ b/applications/KEMCombiner-GHP18/KEMCorrectnessKG.game
@@ -7,12 +7,8 @@ import '../../Primitives/KEM.primitive';
 
 Game FromDecaps(KEM K) {
     [K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute() {
-        [K.PublicKey, K.SecretKey] keys = K.KeyGen();
-        K.PublicKey pk = keys[0];
-        K.SecretKey sk = keys[1];
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(pk);
-        K.SharedSecret ss_e = encaps_result[0];
-        K.Ciphertext ct = encaps_result[1];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss_e, ct] = K.Encaps(pk);
         K.SharedSecret ss_d = K.Decaps(sk, ct);
         return [ct, ss_e, ss_d];
     }
@@ -20,12 +16,8 @@ Game FromDecaps(KEM K) {
 
 Game FromEncaps(KEM K) {
     [K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute() {
-        [K.PublicKey, K.SecretKey] keys = K.KeyGen();
-        K.PublicKey pk = keys[0];
-        K.SecretKey sk = keys[1];
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(pk);
-        K.Ciphertext ct = encaps_result[1];
-        K.SharedSecret ss = encaps_result[0];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ct] = K.Encaps(pk);
         return [ct, ss, ss];
     }
 }

--- a/applications/StarHunters-COSS26/C2PRI.game
+++ b/applications/StarHunters-COSS26/C2PRI.game
@@ -18,12 +18,9 @@ Game Real(KEM K) {
     K.SecretKey sk;
 
     [K.PublicKey, K.SecretKey, K.Ciphertext, K.SharedSecret] Initialize() {
-        [K.PublicKey, K.SecretKey] keys = K.KeyGen();
-        sk = keys[1];
-        [K.SharedSecret, K.Ciphertext] enc = K.Encaps(keys[0]);
-        kStar = enc[0];
-        ctStar = enc[1];
-        return [keys[0], keys[1], enc[1], enc[0]];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [kStar, ctStar] = K.Encaps(pk);
+        return [pk, sk, ctStar, kStar];
     }
 
     Bool Submit(K.Ciphertext ct) {
@@ -38,10 +35,9 @@ Game Ideal(KEM K) {
     K.Ciphertext ctStar;
 
     [K.PublicKey, K.SecretKey, K.Ciphertext, K.SharedSecret] Initialize() {
-        [K.PublicKey, K.SecretKey] keys = K.KeyGen();
-        [K.SharedSecret, K.Ciphertext] enc = K.Encaps(keys[0]);
-        ctStar = enc[1];
-        return [keys[0], keys[1], enc[1], enc[0]];
+        [K.PublicKey, K.SecretKey] [pk, sk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ctStar] = K.Encaps(pk);
+        return [pk, sk, ctStar, ss];
     }
 
     Bool Submit(K.Ciphertext ct) {

--- a/applications/StarHunters-COSS26/CK.scheme
+++ b/applications/StarHunters-COSS26/CK.scheme
@@ -30,12 +30,8 @@ Scheme CK(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) extends KEM {
     [SharedSecret, Ciphertext] Encaps(PublicKey pk) {
         KEM1.PublicKey pk1 = pk[0];
         KEM2.PublicKey pk2 = pk[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] r1 = KEM1.Encaps(pk1);
-        [KEM2.SharedSecret, KEM2.Ciphertext] r2 = KEM2.Encaps(pk2);
-        KEM1.SharedSecret ss1 = r1[0];
-        KEM1.Ciphertext ct1 = r1[1];
-        KEM2.SharedSecret ss2 = r2[0];
-        KEM2.Ciphertext ct2 = r2[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1] = KEM1.Encaps(pk1);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;

--- a/applications/StarHunters-COSS26/CK_INDCCA_PostQuantum.proof
+++ b/applications/StarHunters-COSS26/CK_INDCCA_PostQuantum.proof
@@ -103,16 +103,15 @@ Reduction R_Correct_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, C
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] [ct1Star, ss1e, ss1d] = challenger.Compute(k1[0], sk1);
+        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] [ct1Star, ss1e, ss1d] = challenger.Compute(pk, sk1);
         [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         C.SharedSecret ss = F.evaluate(ss1e, ss2, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -144,16 +143,15 @@ Reduction R_Correct_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, C
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] corr = challenger.Compute(k1[0], sk1);
+        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] corr = challenger.Compute(pk, sk1);
         ct1Star = corr[0];
         ss1d = corr[2];
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         C.SharedSecret ss <- C.SharedSecret;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -265,17 +263,16 @@ Reduction R_PRF_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C)
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         C.SharedSecret ss = challenger.Lookup(ss2, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -307,15 +304,14 @@ Reduction R_PRF_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C)
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         C.SharedSecret ss <- C.SharedSecret;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -346,16 +342,15 @@ Game G_StoredSS1(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         BitString<F.out> ss = F.evaluate(ss1Star, ss2, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -386,10 +381,9 @@ Game G_RandKey(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk);
         ct1Star = rsp1[1];
         ss1Star <- BitString<F.lambda1>;
         [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
@@ -397,7 +391,7 @@ Game G_RandKey(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         BitString<F.out> ss = F.evaluate(ss1Star, ss2, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -428,16 +422,15 @@ Game G_RandKey_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk);
         ct1Star = rsp1[1];
         ss1Star <- BitString<F.lambda1>;
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<F.out> ss <- BitString<F.out>;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -468,14 +461,13 @@ Game G_StoredSS1_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<F.out> ss <- BitString<F.out>;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {

--- a/applications/StarHunters-COSS26/CK_INDCCA_PostQuantum.proof
+++ b/applications/StarHunters-COSS26/CK_INDCCA_PostQuantum.proof
@@ -104,17 +104,10 @@ Reduction R_Correct_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, C
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] corr = challenger.Compute(k1[0], sk1);
-        ct1Star = corr[0];
-        KEM1.SharedSecret ss1e = corr[1];
-        ss1d = corr[2];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] [ct1Star, ss1e, ss1d] = challenger.Compute(k1[0], sk1);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
@@ -152,10 +145,8 @@ Reduction R_Correct_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, C
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
         [KEM1.Ciphertext, KEM1.SharedSecret, KEM1.SharedSecret] corr = challenger.Compute(k1[0], sk1);
         ct1Star = corr[0];
         ss1d = corr[2];
@@ -193,16 +184,9 @@ Reduction R_KEM1_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = challenger.Initialize();
-        KEM1.PublicKey pk1 = rsp1[0];
-        ss1Star = rsp1[1];
-        ct1Star = rsp1[2];
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM1.PublicKey, KEM1.SharedSecret, KEM1.Ciphertext] [pk1, ss1Star, ct1Star] = challenger.Initialize();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
@@ -241,13 +225,8 @@ Reduction R_KEM1_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = challenger.Initialize();
-        KEM1.PublicKey pk1 = rsp1[0];
-        ss1Star = rsp1[1];
-        ct1Star = rsp1[2];
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SharedSecret, KEM1.Ciphertext] [pk1, ss1Star, ct1Star] = challenger.Initialize();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         C.SharedSecret ss <- C.SharedSecret;
@@ -287,15 +266,11 @@ Reduction R_PRF_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C)
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
         ct1Star = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
@@ -333,10 +308,8 @@ Reduction R_PRF_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C)
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
@@ -374,16 +347,10 @@ Game G_StoredSS1(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
@@ -420,16 +387,12 @@ Game G_RandKey(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
         ct1Star = rsp1[1];
         ss1Star <- BitString<F.lambda1>;
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        KEM2.SharedSecret ss2 = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
@@ -466,10 +429,8 @@ Game G_RandKey_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
         ct1Star = rsp1[1];
         ss1Star <- BitString<F.lambda1>;
@@ -508,13 +469,9 @@ Game G_StoredSS1_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<F.out> ss <- BitString<F.out>;

--- a/applications/StarHunters-COSS26/CK_INDCCA_PreQuantum.proof
+++ b/applications/StarHunters-COSS26/CK_INDCCA_PreQuantum.proof
@@ -130,17 +130,10 @@ Reduction R_Correct_2L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, 
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
-        [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] corr = challenger.Compute(pk2, sk2);
-        ct2Star = corr[0];
-        KEM2.SharedSecret ss2e = corr[1];
-        ss2d = corr[2];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] [ct2Star, ss2e, ss2d] = challenger.Compute(pk2, sk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
@@ -178,10 +171,8 @@ Reduction R_Correct_2R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, 
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
         ct1Star = rsp1[1];
         [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] corr = challenger.Compute(pk2, sk2);
@@ -221,13 +212,8 @@ Reduction R_KEM2_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
         sk1 = k1[1];
-        [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = challenger.Initialize();
-        pk2 = rsp2[0];
-        ss2Star = rsp2[1];
-        ct2Star = rsp2[2];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] [pk2, ss2Star, ct2Star] = challenger.Initialize();
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(k1[0]);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
@@ -268,10 +254,7 @@ Reduction R_KEM2_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
         sk1 = k1[1];
-        [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = challenger.Initialize();
-        pk2 = rsp2[0];
-        ss2Star = rsp2[1];
-        ct2Star = rsp2[2];
+        [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] [pk2, ss2Star, ct2Star] = challenger.Initialize();
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
         ct1Star = rsp1[1];
         C.SharedSecret ss <- C.SharedSecret;
@@ -312,14 +295,8 @@ Reduction R_C2PRI_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey, KEM1.Ciphertext, KEM1.SharedSecret] c2pri = challenger.Initialize();
-        KEM1.PublicKey pk1 = c2pri[0];
-        sk1 = c2pri[1];
-        ct1Star = c2pri[2];
-        ss1Star = c2pri[3];
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey, KEM1.Ciphertext, KEM1.SharedSecret] [pk1, sk1, ct1Star, ss1Star] = challenger.Initialize();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
@@ -365,14 +342,8 @@ Reduction R_C2PRI_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey, KEM1.Ciphertext, KEM1.SharedSecret] c2pri = challenger.Initialize();
-        KEM1.PublicKey pk1 = c2pri[0];
-        sk1 = c2pri[1];
-        ct1Star = c2pri[2];
-        ss1Star = c2pri[3];
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
-        pk2 = k2[0];
-        sk2 = k2[1];
+        [KEM1.PublicKey, KEM1.SecretKey, KEM1.Ciphertext, KEM1.SharedSecret] [pk1, sk1, ct1Star, ss1Star] = challenger.Initialize();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
@@ -417,13 +388,9 @@ Reduction R_PRF_Fwd(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<ct2len> bct2 = ct2Star;
@@ -469,13 +436,9 @@ Reduction R_PRF_Rev(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         C.SharedSecret ss <- C.SharedSecret;
@@ -515,16 +478,10 @@ Game G_StoredSS2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        ss2Star = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2Star, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
@@ -561,13 +518,9 @@ Game G_RandSS2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        KEM1.SharedSecret ss1 = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(k1[0]);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
@@ -608,13 +561,9 @@ Game G_Abort(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
@@ -660,13 +609,9 @@ Game G_AllRand(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         RF <- Function<[BitString<F.lambda1>, BitString<F.in>], BitString<F.out>>;
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<ct2len> bct2 = ct2Star;
@@ -710,13 +655,9 @@ Game G_Unwound(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
-        ss1Star = rsp1[0];
-        ct1Star = rsp1[1];
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
@@ -757,10 +698,8 @@ Game G_Consolidated(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
@@ -799,15 +738,11 @@ Game G_StoredSS2_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        [KEM2.PublicKey, KEM2.SecretKey] k2 = KEM2.KeyGen();
+        [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
         sk1 = k1[1];
-        pk2 = k2[0];
-        sk2 = k2[1];
         [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
         ct1Star = rsp1[1];
-        [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
-        ss2Star = rsp2[0];
-        ct2Star = rsp2[1];
+        [KEM2.SharedSecret, KEM2.Ciphertext] [ss2Star, ct2Star] = KEM2.Encaps(pk2);
         BitString<F.out> ss <- BitString<F.out>;
         return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
     }

--- a/applications/StarHunters-COSS26/CK_INDCCA_PreQuantum.proof
+++ b/applications/StarHunters-COSS26/CK_INDCCA_PreQuantum.proof
@@ -129,16 +129,15 @@ Reduction R_Correct_2L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk);
         [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] [ct2Star, ss2e, ss2d] = challenger.Compute(pk2, sk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         C.SharedSecret ss = F.evaluate(ss1, ss2e, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -170,16 +169,15 @@ Reduction R_Correct_2R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, 
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk);
         ct1Star = rsp1[1];
         [KEM2.Ciphertext, KEM2.SharedSecret, KEM2.SharedSecret] corr = challenger.Compute(pk2, sk2);
         ct2Star = corr[0];
         ss2d = corr[2];
         C.SharedSecret ss <- C.SharedSecret;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -210,15 +208,14 @@ Reduction R_KEM2_L(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        sk1 = k1[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] [pk2, ss2Star, ct2Star] = challenger.Initialize();
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         C.SharedSecret ss = F.evaluate(ss1, ss2Star, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -252,13 +249,12 @@ Reduction R_KEM2_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK C
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
-        sk1 = k1[1];
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SharedSecret, KEM2.Ciphertext] [pk2, ss2Star, ct2Star] = challenger.Initialize();
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk);
         ct1Star = rsp1[1];
         C.SharedSecret ss <- C.SharedSecret;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -387,17 +383,16 @@ Reduction R_PRF_Fwd(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK 
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         C.SharedSecret ss = challenger.Lookup(ss1Star, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -435,14 +430,13 @@ Reduction R_PRF_Rev(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len, CK 
 
     [[KEM1.PublicKey, KEM2.PublicKey], C.SharedSecret, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         challenger.Initialize();
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         C.SharedSecret ss <- C.SharedSecret;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     C.SharedSecret? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -477,16 +471,15 @@ Game G_StoredSS2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] [ss2Star, ct2Star] = KEM2.Encaps(pk2);
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         BitString<F.out> ss = F.evaluate(ss1, ss2Star, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -517,10 +510,9 @@ Game G_RandSS2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
@@ -528,7 +520,7 @@ Game G_RandSS2(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         BitString<F.out> ss = F.evaluate(ss1, ss2Star, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -560,10 +552,9 @@ Game G_Abort(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
@@ -571,7 +562,7 @@ Game G_Abort(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         BitString<F.out> ss = F.evaluate(ss1Star, ss2Star, label);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -608,17 +599,16 @@ Game G_AllRand(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
         RF <- Function<[BitString<F.lambda1>, BitString<F.in>], BitString<F.out>>;
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         BitString<ct2len> bct2 = ct2Star;
         BitString<pk2len> bpk2 = pk2;
         BitString<F.in> label = bct2 || bpk2;
         BitString<F.out> ss = RF([ss1Star, label]);
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -654,15 +644,14 @@ Game G_Unwound(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] [ss1Star, ct1Star] = KEM1.Encaps(pk);
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
         BitString<F.out> ss <- BitString<F.out>;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -697,16 +686,15 @@ Game G_Consolidated(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] rsp2 = KEM2.Encaps(pk2);
         ct2Star = rsp2[1];
         ss2Star <- BitString<F.lambda2>;
         BitString<F.out> ss <- BitString<F.out>;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {
@@ -737,14 +725,13 @@ Game G_StoredSS2_R(KEM KEM1, KEM KEM2, TwoKeyPRF F, Int ct2len, Int pk2len) {
     KEM2.Ciphertext ct2Star;
 
     [[KEM1.PublicKey, KEM2.PublicKey], BitString<F.out>, [KEM1.Ciphertext, KEM2.Ciphertext]] Initialize() {
-        [KEM1.PublicKey, KEM1.SecretKey] k1 = KEM1.KeyGen();
+        [KEM1.PublicKey, KEM1.SecretKey] [pk, sk1] = KEM1.KeyGen();
         [KEM2.PublicKey, KEM2.SecretKey] [pk2, sk2] = KEM2.KeyGen();
-        sk1 = k1[1];
-        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(k1[0]);
+        [KEM1.SharedSecret, KEM1.Ciphertext] rsp1 = KEM1.Encaps(pk);
         ct1Star = rsp1[1];
         [KEM2.SharedSecret, KEM2.Ciphertext] [ss2Star, ct2Star] = KEM2.Encaps(pk2);
         BitString<F.out> ss <- BitString<F.out>;
-        return [[k1[0], pk2], ss, [ct1Star, ct2Star]];
+        return [[pk, pk2], ss, [ct1Star, ct2Star]];
     }
 
     BitString<F.out>? Decaps([KEM1.Ciphertext, KEM2.Ciphertext] c) {

--- a/applications/StarHunters-COSS26/INDCCA_PKE.game
+++ b/applications/StarHunters-COSS26/INDCCA_PKE.game
@@ -13,9 +13,7 @@ Game Left(PKE E) {
     Bool challenged;
 
     E.PublicKey Initialize() {
-        [E.PublicKey, E.SecretKey] k = E.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
         challenged = false;
         return pk;
     }
@@ -44,9 +42,7 @@ Game Right(PKE E) {
     Bool challenged;
 
     E.PublicKey Initialize() {
-        [E.PublicKey, E.SecretKey] k = E.KeyGen();
-        pk = k[0];
-        sk = k[1];
+        [E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
         challenged = false;
         return pk;
     }

--- a/applications/cfrg-hybrid-kems/games/KEM/Binding/HON_BIND_K_PK.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/Binding/HON_BIND_K_PK.game
@@ -31,12 +31,8 @@ Game Breakable(KEM K) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.EncapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        ek0 = kp0[0];
-        dk0 = kp0[1];
-        ek1 = kp1[0];
-        dk1 = kp1[1];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
         return [ek0, ek1];
     }
 
@@ -62,12 +58,8 @@ Game Unbreakable(KEM K) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.EncapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        ek0 = kp0[0];
-        dk0 = kp0[1];
-        ek1 = kp1[0];
-        dk1 = kp1[1];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
         return [ek0, ek1];
     }
 

--- a/applications/cfrg-hybrid-kems/games/KEM/Binding/LEAK_BIND_K_PK.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/Binding/LEAK_BIND_K_PK.game
@@ -27,12 +27,8 @@ Game Breakable(KEM K) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        ek0 = kp0[0];
-        dk0 = kp0[1];
-        ek1 = kp1[0];
-        dk1 = kp1[1];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
         return [ek0, dk0, ek1, dk1];
     }
 
@@ -50,12 +46,8 @@ Game Unbreakable(KEM K) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        ek0 = kp0[0];
-        dk0 = kp0[1];
-        ek1 = kp1[0];
-        dk1 = kp1[1];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
         return [ek0, dk0, ek1, dk1];
     }
 

--- a/applications/cfrg-hybrid-kems/games/KEM/Binding/LEAK_BIND_K_PK_ROM.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/Binding/LEAK_BIND_K_PK_ROM.game
@@ -20,12 +20,8 @@ Game Breakable(KEM K, Set D, Set R, Function<D, R> G_RO) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        ek0 = kp0[0];
-        dk0 = kp0[1];
-        ek1 = kp1[0];
-        dk1 = kp1[1];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
         return [ek0, dk0, ek1, dk1];
     }
 
@@ -47,12 +43,8 @@ Game Unbreakable(KEM K, Set D, Set R, Function<D, R> G_RO) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        ek0 = kp0[0];
-        dk0 = kp0[1];
-        ek1 = kp1[0];
-        dk1 = kp1[1];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
         return [ek0, dk0, ek1, dk1];
     }
 

--- a/applications/cfrg-hybrid-kems/games/KEM/C2PRI.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/C2PRI.game
@@ -20,12 +20,9 @@ Game Real(KEM K) {
     K.DecapsKey dk;
 
     [K.EncapsKey, K.DecapsKey, K.Ciphertext, K.SharedSecret] Initialize() {
-        [K.EncapsKey, K.DecapsKey] keys = K.KeyGen();
-        dk = keys[1];
-        [K.SharedSecret, K.Ciphertext] enc = K.Encaps(keys[0]);
-        kStar = enc[0];
-        ctStar = enc[1];
-        return [keys[0], keys[1], enc[1], enc[0]];
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [kStar, ctStar] = K.Encaps(ek);
+        return [ek, dk, ctStar, kStar];
     }
 
     Bool Submit(K.Ciphertext ct) {
@@ -40,10 +37,9 @@ Game Ideal(KEM K) {
     K.Ciphertext ctStar;
 
     [K.EncapsKey, K.DecapsKey, K.Ciphertext, K.SharedSecret] Initialize() {
-        [K.EncapsKey, K.DecapsKey] keys = K.KeyGen();
-        [K.SharedSecret, K.Ciphertext] enc = K.Encaps(keys[0]);
-        ctStar = enc[1];
-        return [keys[0], keys[1], enc[1], enc[0]];
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ctStar] = K.Encaps(ek);
+        return [ek, dk, ctStar, ss];
     }
 
     Bool Submit(K.Ciphertext ct) {

--- a/applications/cfrg-hybrid-kems/games/KEM/Correctness.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/Correctness.game
@@ -19,18 +19,18 @@ import '../../primitives/KEM.primitive';
 
 Game FromDecaps(KEM K) {
     [K.EncapsKey, K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute() {
-        [K.EncapsKey, K.DecapsKey] keys = K.KeyGen();
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(keys[0]);
-        K.SharedSecret ss_d = K.Decaps(keys[1], encaps_result[1]);
-        return [keys[0], encaps_result[1], encaps_result[0], ss_d];
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ct] = K.Encaps(ek);
+        K.SharedSecret ss_d = K.Decaps(dk, ct);
+        return [ek, ct, ss, ss_d];
     }
 }
 
 Game FromEncaps(KEM K) {
     [K.EncapsKey, K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute() {
         [K.EncapsKey, K.DecapsKey] keys = K.KeyGen();
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(keys[0]);
-        return [keys[0], encaps_result[1], encaps_result[0], encaps_result[0]];
+        [K.SharedSecret, K.Ciphertext] [ss, ct] = K.Encaps(keys[0]);
+        return [keys[0], ct, ss, ss];
     }
 }
 

--- a/applications/cfrg-hybrid-kems/games/KEM/CorrectnessWithDK.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/CorrectnessWithDK.game
@@ -13,18 +13,18 @@ import '../../primitives/KEM.primitive';
 
 Game FromDecaps(KEM K) {
     [K.EncapsKey, K.DecapsKey, K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute() {
-        [K.EncapsKey, K.DecapsKey] keys = K.KeyGen();
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(keys[0]);
-        K.SharedSecret ss_d = K.Decaps(keys[1], encaps_result[1]);
-        return [keys[0], keys[1], encaps_result[1], encaps_result[0], ss_d];
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ct] = K.Encaps(ek);
+        K.SharedSecret ss_d = K.Decaps(dk, ct);
+        return [ek, dk, ct, ss, ss_d];
     }
 }
 
 Game FromEncaps(KEM K) {
     [K.EncapsKey, K.DecapsKey, K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute() {
-        [K.EncapsKey, K.DecapsKey] keys = K.KeyGen();
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(keys[0]);
-        return [keys[0], keys[1], encaps_result[1], encaps_result[0], encaps_result[0]];
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ct] = K.Encaps(ek);
+        return [ek, dk, ct, ss, ss];
     }
 }
 

--- a/applications/cfrg-hybrid-kems/games/KEM/INDCCA.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/INDCCA.game
@@ -14,11 +14,9 @@ Game Real(KEM K) {
     K.Ciphertext ctStar;
 
     [K.EncapsKey, K.SharedSecret, K.Ciphertext] Initialize() {
-        [K.EncapsKey, K.DecapsKey] k = K.KeyGen();
-        dk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
-        ctStar = rsp[1];
-        return [k[0], rsp[0], rsp[1]];
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ctStar] = K.Encaps(ek);
+        return [ek, ss, ctStar];
     }
 
     K.SharedSecret? Decaps(K.Ciphertext c) {
@@ -34,12 +32,10 @@ Game Random(KEM K) {
     K.Ciphertext ctStar;
 
     [K.EncapsKey, K.SharedSecret, K.Ciphertext] Initialize() {
-        [K.EncapsKey, K.DecapsKey] k = K.KeyGen();
-        dk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss_unused, ctStar] = K.Encaps(ek);
         K.SharedSecret ss <- K.SharedSecret;
-        ctStar = rsp[1];
-        return [k[0], ss, rsp[1]];
+        return [ek, ss, ctStar];
     }
 
     K.SharedSecret? Decaps(K.Ciphertext c) {

--- a/applications/cfrg-hybrid-kems/games/KEM/INDCCA_ROM.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/INDCCA_ROM.game
@@ -17,11 +17,9 @@ Game Real(KEM K, Set D, Set R, Function<D, R> H) {
     K.Ciphertext ctStar;
 
     [K.EncapsKey, K.SharedSecret, K.Ciphertext] Initialize() {
-        [K.EncapsKey, K.DecapsKey] k = K.KeyGen();
-        dk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
-        ctStar = rsp[1];
-        return [k[0], rsp[0], rsp[1]];
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ctStar] = K.Encaps(ek);
+        return [ek, ss, ctStar];
     }
 
     K.SharedSecret? Decaps(K.Ciphertext c) {
@@ -41,12 +39,11 @@ Game Random(KEM K, Set D, Set R, Function<D, R> H) {
     K.Ciphertext ctStar;
 
     [K.EncapsKey, K.SharedSecret, K.Ciphertext] Initialize() {
-        [K.EncapsKey, K.DecapsKey] k = K.KeyGen();
-        dk = k[1];
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(k[0]);
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(ek);
         K.SharedSecret ss <- K.SharedSecret;
         ctStar = rsp[1];
-        return [k[0], ss, rsp[1]];
+        return [ek, ss, rsp[1]];
     }
 
     K.SharedSecret? Decaps(K.Ciphertext c) {

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_Correctness.proof
@@ -72,11 +72,7 @@ games:
 Reduction R_KEM_PQ(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_expanded hybrid)
     compose KEMCorrectness(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] pq_result = challenger.Compute();
-        KEM_PQ.EncapsKey ek_PQ = pq_result[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_result[1];
-        KEM_PQ.SharedSecret ss_PQ_e = pq_result[2];
-        KEM_PQ.SharedSecret ss_PQ_d = pq_result[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] [ek_PQ, ct_PQ, ss_PQ_e, ss_PQ_d] = challenger.Compute();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -96,9 +92,7 @@ Reduction R_NG(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_expanded hybrid)
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_INDCCA_PQ.proof
@@ -186,9 +186,7 @@ Game GameCaseSplitReal(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_ex
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -229,9 +227,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_e
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -269,10 +265,7 @@ Reduction RB(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_expanded hyb
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -312,10 +305,7 @@ Reduction RC(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_expanded hyb
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_INDCCA_T.proof
@@ -133,15 +133,11 @@ Reduction R_Dist_Real(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_expanded h
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Scalar, NG.Scalar] dist = challenger.Initialize();
-        dk_T = dist[0];
-        NG.Scalar sk_E = dist[1];
+        [NG.Scalar, NG.Scalar] [dk_T, sk_E] = challenger.Initialize();
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<NG.Nss> ss_T = NG.ElementToSharedSecret(NG.Exp(ek_T, sk_E));
         BitString<hybrid.Nin> kdf_in =
@@ -174,9 +170,7 @@ Reduction R_Dist_Random(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_expanded
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Scalar, NG.Scalar] dist = challenger.Initialize();
-        dk_T = dist[0];
-        NG.Scalar sk_E = dist[1];
+        [NG.Scalar, NG.Scalar] [dk_T, sk_E] = challenger.Initialize();
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
@@ -219,11 +213,7 @@ Reduction R_C2PRI_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_expanded hyb
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] c2pri = challenger.Initialize();
-        ek_PQ = c2pri[0];
-        dk_PQ = c2pri[1];
-        ct_PQ_star = c2pri[2];
-        ss_PQ_star = c2pri[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         dk_T <- NG.Scalar;
         ek_T = NG.Exp(NG.Generator(), dk_T);
         NG.Scalar sk_E <- NG.Scalar;
@@ -269,11 +259,7 @@ Reduction R_C2PRI_R(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_expanded hyb
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] c2pri = challenger.Initialize();
-        ek_PQ = c2pri[0];
-        dk_PQ = c2pri[1];
-        ct_PQ_star = c2pri[2];
-        ss_PQ_star = c2pri[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         dk_T <- NG.Scalar;
         ek_T = NG.Exp(NG.Generator(), dk_T);
         NG.Scalar sk_E <- NG.Scalar;
@@ -315,14 +301,10 @@ Reduction R_Wrap_Prog(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G, La
     NG.Element ct_T_star;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        ct_PQ_star = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ_star] = KEM_PQ.Encaps(ek_PQ);
         NG.Scalar sk_E <- NG.Scalar;
         ct_T_star = NG.Exp(NG.Generator(), sk_E);
         BitString<NG.Nss> ss_T = NG.ElementToSharedSecret(NG.Exp(ek_T, sk_E));
@@ -363,14 +345,10 @@ Reduction R_Wrap_NoAbort(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G,
     NG.Element ct_T_star;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        ct_PQ_star = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ_star] = KEM_PQ.Encaps(ek_PQ);
         NG.Scalar sk_E <- NG.Scalar;
         ct_T_star = NG.Exp(NG.Generator(), sk_E);
         [KEM_PQ.Ciphertext, NG.Element] ctStar = [ct_PQ_star, ct_T_star];
@@ -411,15 +389,9 @@ Reduction R_Combined(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_expanded hy
     Map<[KEM_PQ.Ciphertext, NG.Element], BitString<hybrid.Nss>> QT;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Element, NG.Element] chal = challenger.Initialize();
-        ek_T = chal[0];
-        NG.Element ct_T = chal[1];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        ek_PQ = pq_keys[0];
-        dk_PQ = pq_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [NG.Element, NG.Element] [ek_T, ct_T] = challenger.Initialize();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         ctStar = [ct_PQ, ct_T];
         ss_star <- BitString<hybrid.Nss>;
         return [[ek_PQ, ek_T], ss_star, ctStar];
@@ -466,9 +438,7 @@ Reduction R_Combined(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_expanded hy
         }
         if (m in HT) { return HT[m]; }
         for ([[KEM_PQ.Ciphertext, NG.Element], BitString<hybrid.Nss>] e in QT.entries) {
-            [KEM_PQ.Ciphertext, NG.Element] c_key = e[0];
-            KEM_PQ.Ciphertext c_PQ = c_key[0];
-            NG.Element c_T = c_key[1];
+            [KEM_PQ.Ciphertext, NG.Element] [c_PQ, c_T] = e[0];
             KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(dk_PQ, c_PQ);
             if (m[0 : KEM_PQ.Nss] == KEM_PQ.EncodeSharedSecret(ss_PQ)
                 && challenger.DH(c_T, ss_T_slot)

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_LEAK_BIND_K_CT.proof
@@ -78,11 +78,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_expanded hyb
     NG.Element ek_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Initialize();
-        KEM_PQ.EncapsKey ek_PQ_0 = pq_keys[0];
-        dk_PQ_0 = pq_keys[1];
-        KEM_PQ.EncapsKey ek_PQ_1 = pq_keys[2];
-        dk_PQ_1 = pq_keys[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0, ek_PQ_1, dk_PQ_1] = challenger.Initialize();
         BitString<NG.Nseed> seed_T_0 <- BitString<NG.Nseed>;
         BitString<NG.Nseed> seed_T_1 <- BitString<NG.Nseed>;
         dk_T_0 = NG.RandomScalar(seed_T_0);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_LEAK_BIND_K_PK.proof
@@ -94,11 +94,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_expanded hyb
     NG.Element ek_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Initialize();
-        ek_PQ_0 = pq_keys[0];
-        dk_PQ_0 = pq_keys[1];
-        ek_PQ_1 = pq_keys[2];
-        dk_PQ_1 = pq_keys[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0, ek_PQ_1, dk_PQ_1] = challenger.Initialize();
         BitString<NG.Nseed> seed_T_0 <- BitString<NG.Nseed>;
         BitString<NG.Nseed> seed_T_1 <- BitString<NG.Nseed>;
         dk_T_0 = NG.RandomScalar(seed_T_0);
@@ -143,14 +139,10 @@ Reduction R_KDF(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_expanded hybrid)
     NG.Element ek_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.KeyGen();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.KeyGen();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.KeyGen();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.KeyGen();
         BitString<NG.Nseed> seed_T_0 <- BitString<NG.Nseed>;
         BitString<NG.Nseed> seed_T_1 <- BitString<NG.Nseed>;
-        ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
         dk_T_0 = NG.RandomScalar(seed_T_0);
         dk_T_1 = NG.RandomScalar(seed_T_1);
         ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_Correctness.proof
@@ -110,14 +110,10 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
         BitString<G.lambda + G.stretch> seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -133,15 +129,11 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
 Reduction R_KG_PQ_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased hybrid)
     compose KeyGenEquiv(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = challenger.Generate();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -159,11 +151,7 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedb
 Reduction R_KEM_PQ(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased hybrid)
     compose KEMCorrectness(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] pq_result = challenger.Compute();
-        KEM_PQ.EncapsKey ek_PQ = pq_result[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_result[1];
-        KEM_PQ.SharedSecret ss_PQ_e = pq_result[2];
-        KEM_PQ.SharedSecret ss_PQ_d = pq_result[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] [ek_PQ, ct_PQ, ss_PQ_e, ss_PQ_d] = challenger.Compute();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -188,9 +176,7 @@ Reduction R_NG(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased 
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -215,9 +201,7 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedb
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -238,9 +222,7 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_HON_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_HON_BIND_K_CT.proof
@@ -229,14 +229,14 @@ Reduction R_PQ_Bind(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_seedbased hy
     NG.Element ek_T_1;
 
     [hybrid.EncapsKey, hybrid.EncapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.EncapsKey] pq_eks = challenger.Initialize();
+        [KEM_PQ.EncapsKey, KEM_PQ.EncapsKey] [ek_PQ_0, ek_PQ_1] = challenger.Initialize();
         BitString<NG.Nseed> seed_T_0 <- BitString<NG.Nseed>;
         dk_T_0 = NG.RandomScalar(seed_T_0);
         ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);
         BitString<NG.Nseed> seed_T_1 <- BitString<NG.Nseed>;
         dk_T_1 = NG.RandomScalar(seed_T_1);
         ek_T_1 = NG.Exp(NG.Generator(), dk_T_1);
-        return [[pq_eks[0], ek_T_0], [pq_eks[1], ek_T_1]];
+        return [[ek_PQ_0, ek_T_0], [ek_PQ_1, ek_T_1]];
     }
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_HON_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_HON_BIND_K_PK.proof
@@ -236,9 +236,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_seedbased hy
     NG.Element ek_T_1;
 
     [hybrid.EncapsKey, hybrid.EncapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.EncapsKey] pq_eks = challenger.Initialize();
-        ek_PQ_0 = pq_eks[0];
-        ek_PQ_1 = pq_eks[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.EncapsKey] [ek_PQ_0, ek_PQ_1] = challenger.Initialize();
         BitString<NG.Nseed> seed_T_0 <- BitString<NG.Nseed>;
         dk_T_0 = NG.RandomScalar(seed_T_0);
         ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_INDCCA_PQ.proof
@@ -119,9 +119,7 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
         KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -200,9 +198,7 @@ Reduction R_KG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbase
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -356,9 +352,7 @@ Game GameCaseSplitReal(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_se
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -399,9 +393,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_s
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -439,10 +431,7 @@ Reduction RB(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased hy
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -482,10 +471,7 @@ Reduction RC(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased hy
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_INDCCA_T.proof
@@ -167,9 +167,7 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hybr
         KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -259,9 +257,7 @@ Reduction R_KG_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hybri
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -339,15 +335,11 @@ Reduction R_Dist_Real(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased 
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Scalar, NG.Scalar] dist = challenger.Initialize();
-        dk_T = dist[0];
-        NG.Scalar sk_E = dist[1];
+        [NG.Scalar, NG.Scalar] [dk_T, sk_E] = challenger.Initialize();
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<NG.Nss> ss_T = NG.ElementToSharedSecret(NG.Exp(ek_T, sk_E));
         BitString<hybrid.Nin> kdf_in =
@@ -380,9 +372,7 @@ Reduction R_Dist_Random(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbase
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Scalar, NG.Scalar] dist = challenger.Initialize();
-        dk_T = dist[0];
-        NG.Scalar sk_E = dist[1];
+        [NG.Scalar, NG.Scalar] [dk_T, sk_E] = challenger.Initialize();
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
@@ -433,11 +423,7 @@ Reduction R_C2PRI_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hy
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] c2pri = challenger.Initialize();
-        ek_PQ = c2pri[0];
-        dk_PQ = c2pri[1];
-        ct_PQ_star = c2pri[2];
-        ss_PQ_star = c2pri[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         dk_T <- NG.Scalar;
         ek_T = NG.Exp(NG.Generator(), dk_T);
         NG.Scalar sk_E <- NG.Scalar;
@@ -483,11 +469,7 @@ Reduction R_C2PRI_R(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hy
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] c2pri = challenger.Initialize();
-        ek_PQ = c2pri[0];
-        dk_PQ = c2pri[1];
-        ct_PQ_star = c2pri[2];
-        ss_PQ_star = c2pri[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         dk_T <- NG.Scalar;
         ek_T = NG.Exp(NG.Generator(), dk_T);
         NG.Scalar sk_E <- NG.Scalar;
@@ -539,14 +521,10 @@ Reduction R_Wrap_Prog(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G, La
     NG.Element ct_T_star;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        ct_PQ_star = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ_star] = KEM_PQ.Encaps(ek_PQ);
         NG.Scalar sk_E <- NG.Scalar;
         ct_T_star = NG.Exp(NG.Generator(), sk_E);
         BitString<NG.Nss> ss_T = NG.ElementToSharedSecret(NG.Exp(ek_T, sk_E));
@@ -590,14 +568,10 @@ Reduction R_Wrap_NoAbort(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G,
     NG.Element ct_T_star;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        ct_PQ_star = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ_star] = KEM_PQ.Encaps(ek_PQ);
         NG.Scalar sk_E <- NG.Scalar;
         ct_T_star = NG.Exp(NG.Generator(), sk_E);
         [KEM_PQ.Ciphertext, NG.Element] ctStar = [ct_PQ_star, ct_T_star];
@@ -645,15 +619,9 @@ Reduction R_Combined(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased h
     Map<[KEM_PQ.Ciphertext, NG.Element], BitString<hybrid.Nss>> QT;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Element, NG.Element] chal = challenger.Initialize();
-        ek_T = chal[0];
-        NG.Element ct_T = chal[1];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        ek_PQ = pq_keys[0];
-        dk_PQ = pq_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [NG.Element, NG.Element] [ek_T, ct_T] = challenger.Initialize();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         ctStar = [ct_PQ, ct_T];
         ss_star <- BitString<hybrid.Nss>;
         return [[ek_PQ, ek_T], ss_star, ctStar];
@@ -700,9 +668,7 @@ Reduction R_Combined(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased h
         }
         if (m in HT) { return HT[m]; }
         for ([[KEM_PQ.Ciphertext, NG.Element], BitString<hybrid.Nss>] e in QT.entries) {
-            [KEM_PQ.Ciphertext, NG.Element] c_key = e[0];
-            KEM_PQ.Ciphertext c_PQ = c_key[0];
-            NG.Element c_T = c_key[1];
+            [KEM_PQ.Ciphertext, NG.Element] [c_PQ, c_T] = e[0];
             KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(dk_PQ, c_PQ);
             if (m[0 : KEM_PQ.Nss] == KEM_PQ.EncodeSharedSecret(ss_PQ)
                 && challenger.DH(c_T, ss_T_slot)

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_CT.proof
@@ -440,10 +440,8 @@ Reduction R_KDF(KEM KEM_PQ, NominalGroup NG, Int lambda,
         s_PQ_1 <- BitString<KEM_PQ.Nseed>;
         s_T_0 <- BitString<NG.Nseed>;
         s_T_1 <- BitString<NG.Nseed>;
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(s_PQ_0);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(s_PQ_1);
-        ek_PQ_0 = pq_kp_0[0]; dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0]; dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.DeriveKeyPair(s_PQ_0);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.DeriveKeyPair(s_PQ_1);
         dk_T_0 = NG.RandomScalar(s_T_0);
         dk_T_1 = NG.RandomScalar(s_T_1);
         NG.Element ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_CT.proof
@@ -179,9 +179,7 @@ Reduction R_LazyRO_L(KEM KEM_PQ, NominalGroup NG, Int lambda,
     NG.Scalar dk_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [BitString<lambda>, BitString<lambda>] seeds = challenger.Initialize();
-        BitString<lambda> seed_0 = seeds[0];
-        BitString<lambda> seed_1 = seeds[1];
+        [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         BitString<KEM_PQ.Nseed + NG.Nseed> y_0 = challenger.Hash(seed_0);
         BitString<KEM_PQ.Nseed + NG.Nseed> y_1 = challenger.Hash(seed_1);
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
@@ -222,9 +220,7 @@ Reduction R_LazyRO_R(KEM KEM_PQ, NominalGroup NG, Int lambda,
     NG.Scalar dk_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [BitString<lambda>, BitString<lambda>] seeds = challenger.Initialize();
-        BitString<lambda> seed_0 = seeds[0];
-        BitString<lambda> seed_1 = seeds[1];
+        [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         BitString<KEM_PQ.Nseed + NG.Nseed> y_0 = challenger.Hash(seed_0);
         BitString<KEM_PQ.Nseed + NG.Nseed> y_1 = challenger.Hash(seed_1);
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
@@ -267,12 +263,8 @@ Reduction R_KG_L(KEM KEM_PQ, NominalGroup NG, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = challenger.Generate();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = challenger.Generate();
-        KEM_PQ.EncapsKey ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        KEM_PQ.EncapsKey ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = challenger.Generate();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<NG.Nseed>;
@@ -325,12 +317,8 @@ Reduction R_KG_R(KEM KEM_PQ, NominalGroup NG, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = challenger.Generate();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = challenger.Generate();
-        KEM_PQ.EncapsKey ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        KEM_PQ.EncapsKey ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = challenger.Generate();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<NG.Nseed>;
@@ -382,11 +370,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, NominalGroup NG, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Initialize();
-        KEM_PQ.EncapsKey ek_PQ_0 = pq_keys[0];
-        s_PQ_0 = pq_keys[1];
-        KEM_PQ.EncapsKey ek_PQ_1 = pq_keys[2];
-        s_PQ_1 = pq_keys[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, s_PQ_0, ek_PQ_1, s_PQ_1] = challenger.Initialize();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<NG.Nseed>;

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_PK.proof
@@ -477,10 +477,8 @@ Reduction R_KDF(KEM KEM_PQ, NominalGroup NG, Int lambda,
         s_PQ_1 <- BitString<KEM_PQ.Nseed>;
         s_T_0 <- BitString<NG.Nseed>;
         s_T_1 <- BitString<NG.Nseed>;
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(s_PQ_0);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(s_PQ_1);
-        ek_PQ_0 = pq_kp_0[0]; dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0]; dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.DeriveKeyPair(s_PQ_0);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.DeriveKeyPair(s_PQ_1);
         dk_T_0 = NG.RandomScalar(s_T_0);
         dk_T_1 = NG.RandomScalar(s_T_1);
         ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_PK.proof
@@ -187,17 +187,11 @@ Reduction R_LazyRO_L(KEM KEM_PQ, NominalGroup NG, Int lambda,
     NG.Scalar dk_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [BitString<lambda>, BitString<lambda>] seeds = challenger.Initialize();
-        BitString<lambda> seed_0 = seeds[0];
-        BitString<lambda> seed_1 = seeds[1];
+        [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         BitString<KEM_PQ.Nseed + NG.Nseed> y_0 = challenger.Hash(seed_0);
         BitString<KEM_PQ.Nseed + NG.Nseed> y_1 = challenger.Hash(seed_1);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(y_1[0 : KEM_PQ.Nseed]);
-        ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.DeriveKeyPair(y_1[0 : KEM_PQ.Nseed]);
         dk_T_0 = NG.RandomScalar(y_0[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed]);
         dk_T_1 = NG.RandomScalar(y_1[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed]);
         ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);
@@ -238,17 +232,11 @@ Reduction R_LazyRO_R(KEM KEM_PQ, NominalGroup NG, Int lambda,
     NG.Scalar dk_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [BitString<lambda>, BitString<lambda>] seeds = challenger.Initialize();
-        BitString<lambda> seed_0 = seeds[0];
-        BitString<lambda> seed_1 = seeds[1];
+        [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         BitString<KEM_PQ.Nseed + NG.Nseed> y_0 = challenger.Hash(seed_0);
         BitString<KEM_PQ.Nseed + NG.Nseed> y_1 = challenger.Hash(seed_1);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(y_1[0 : KEM_PQ.Nseed]);
-        ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.DeriveKeyPair(y_1[0 : KEM_PQ.Nseed]);
         dk_T_0 = NG.RandomScalar(y_0[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed]);
         dk_T_1 = NG.RandomScalar(y_1[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed]);
         ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);
@@ -291,12 +279,8 @@ Reduction R_KG_L(KEM KEM_PQ, NominalGroup NG, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = challenger.Generate();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = challenger.Generate();
-        ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = challenger.Generate();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<NG.Nseed>;
@@ -355,12 +339,8 @@ Reduction R_KG_R(KEM KEM_PQ, NominalGroup NG, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = challenger.Generate();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = challenger.Generate();
-        ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = challenger.Generate();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<NG.Nseed>;
@@ -419,11 +399,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, NominalGroup NG, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Initialize();
-        ek_PQ_0 = pq_keys[0];
-        s_PQ_0 = pq_keys[1];
-        ek_PQ_1 = pq_keys[2];
-        s_PQ_1 = pq_keys[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, s_PQ_0, ek_PQ_1, s_PQ_1] = challenger.Initialize();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<NG.Nseed>;

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_Correctness.proof
@@ -74,17 +74,9 @@ games:
 Reduction R_KEM_PQ(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
     compose KEMCorrectness(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] pq_result = challenger.Compute();
-        KEM_PQ.EncapsKey ek_PQ = pq_result[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_result[1];
-        KEM_PQ.SharedSecret ss_PQ_e = pq_result[2];
-        KEM_PQ.SharedSecret ss_PQ_d = pq_result[3];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.KeyGen();
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] [ek_PQ, ct_PQ, ss_PQ_e, ss_PQ_d] = challenger.Compute();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.KeyGen();
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ_d) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -95,16 +87,10 @@ Reduction R_KEM_PQ(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
 Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
     compose KEMCorrectness(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] t_result = challenger.Compute();
-        KEM_T.EncapsKey ek_T = t_result[0];
-        KEM_T.Ciphertext ct_T = t_result[1];
-        KEM_T.SharedSecret ss_T_e = t_result[2];
-        KEM_T.SharedSecret ss_T_d = t_result[3];
+        [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] [ek_T, ct_T, ss_T_e, ss_T_d] = challenger.Compute();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], H.evaluate(kdf_in_e), H.evaluate(kdf_in_d)];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_INDCCA_PQ.proof
@@ -110,9 +110,7 @@ Reduction R_Correct_Real(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expand
         KEM_PQ.Ciphertext ct_PQ = corr[2];
         KEM_PQ.SharedSecret ss_PQ_e = corr[3];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -183,13 +181,9 @@ Game GameCaseSplitReal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -223,9 +217,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expande
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
@@ -261,15 +253,10 @@ Reduction RB(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [kem_ct, ct_T];
@@ -301,10 +288,7 @@ Reduction RC(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
@@ -348,9 +332,7 @@ Reduction RD(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
         kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_T.EncodeSharedSecret(ss_T), rest);
         ctStar = [kem_ct, ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_INDCCA_T.proof
@@ -127,9 +127,7 @@ Reduction R_Correct_T_Real(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expa
         KEM_T.Ciphertext ct_T = corr[2];
         KEM_T.SharedSecret ss_T_e = corr[3];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -200,12 +198,8 @@ Game G_StoredSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybr
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        ss_T_star = t_enc[0];
-        kem_ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_star) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, kem_ct_T];
@@ -239,15 +233,10 @@ Reduction R_KEM_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] ch = challenger.Initialize();
-        ek_T = ch[0];
-        ss_T_star = ch[1];
-        kem_ct_T = ch[2];
+        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_star) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, kem_ct_T];
@@ -279,10 +268,7 @@ Reduction R_KEM_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] ch = challenger.Initialize();
-        ek_T = ch[0];
-        ss_T_star = ch[1];
-        kem_ct_T = ch[2];
+        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
@@ -323,9 +309,7 @@ Game G_RandSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         ss_T_star <- BitString<KEM_T.Nss>;
@@ -365,11 +349,7 @@ Reduction R_C2PRI_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] c2pri = challenger.Initialize();
-        ek_PQ = c2pri[0];
-        dk_PQ = c2pri[1];
-        ct_PQ_star = c2pri[2];
-        ss_PQ_star = c2pri[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
@@ -413,11 +393,7 @@ Reduction R_C2PRI_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] c2pri = challenger.Initialize();
-        ek_PQ = c2pri[0];
-        dk_PQ = c2pri[1];
-        ct_PQ_star = c2pri[2];
-        ss_PQ_star = c2pri[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
@@ -464,9 +440,7 @@ Game G_Abort(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid) {
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         ss_T_star <- BitString<KEM_T.Nss>;
@@ -512,9 +486,7 @@ Reduction R_PRF_Fwd(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -556,9 +528,7 @@ Reduction R_PRF_Rev(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         kem_ct_T = _t_enc_tmp[1];
         BitString<H.Nout> ss <- BitString<H.Nout>;
@@ -602,9 +572,7 @@ Game G_AllRand(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         kem_ct_T = _t_enc_tmp[1];
         BitString<H.Nout> ss <- BitString<H.Nout>;
@@ -647,9 +615,7 @@ Game G_Unwound(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         kem_ct_T = _t_enc_tmp[1];
         ss_T_star <- BitString<KEM_T.Nss>;
@@ -734,9 +700,7 @@ Game G_StoredSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        ss_T_star = t_enc[0];
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_LEAK_BIND_K_CT.proof
@@ -101,11 +101,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
     KEM_T.EncapsKey ek_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Initialize();
-        KEM_PQ.EncapsKey ek_PQ_0 = pq_keys[0];
-        dk_PQ_0 = pq_keys[1];
-        KEM_PQ.EncapsKey ek_PQ_1 = pq_keys[2];
-        dk_PQ_1 = pq_keys[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0, ek_PQ_1, dk_PQ_1] = challenger.Initialize();
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.KeyGen();
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.KeyGen();
         dk_T_0 = t_kp_0[1];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_LEAK_BIND_K_PK.proof
@@ -103,11 +103,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
     KEM_T.EncapsKey ek_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Initialize();
-        ek_PQ_0 = pq_keys[0];
-        dk_PQ_0 = pq_keys[1];
-        ek_PQ_1 = pq_keys[2];
-        dk_PQ_1 = pq_keys[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0, ek_PQ_1, dk_PQ_1] = challenger.Initialize();
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.KeyGen();
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.KeyGen();
         dk_T_0 = t_kp_0[1];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_Correctness.proof
@@ -117,18 +117,10 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         BitString<G.lambda + G.stretch> seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_PQ.SharedSecret ss_PQ_d = KEM_PQ.Decaps(dk_PQ, ct_PQ);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -140,19 +132,11 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
 Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
     compose KeyGenEquiv(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = challenger.Generate();
         BitString<KEM_T.Nseed> seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_PQ.SharedSecret ss_PQ_d = KEM_PQ.Decaps(dk_PQ, ct_PQ);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -164,18 +148,10 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 Reduction R_KG_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
     compose KeyGenEquiv(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = challenger.Generate();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = challenger.Generate();
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_PQ.SharedSecret ss_PQ_d = KEM_PQ.Decaps(dk_PQ, ct_PQ);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -188,17 +164,9 @@ Reduction R_KG_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hy
 Reduction R_KEM_PQ(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
     compose KEMCorrectness(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] pq_result = challenger.Compute();
-        KEM_PQ.EncapsKey ek_PQ = pq_result[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_result[1];
-        KEM_PQ.SharedSecret ss_PQ_e = pq_result[2];
-        KEM_PQ.SharedSecret ss_PQ_d = pq_result[3];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.KeyGen();
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] [ek_PQ, ct_PQ, ss_PQ_e, ss_PQ_d] = challenger.Compute();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.KeyGen();
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ_d) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -209,16 +177,10 @@ Reduction R_KEM_PQ(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hy
 Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
     compose KEMCorrectness(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] t_result = challenger.Compute();
-        KEM_T.EncapsKey ek_T = t_result[0];
-        KEM_T.Ciphertext ct_T = t_result[1];
-        KEM_T.SharedSecret ss_T_e = t_result[2];
-        KEM_T.SharedSecret ss_T_d = t_result[3];
+        [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] [ek_T, ct_T, ss_T_e, ss_T_d] = challenger.Compute();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], H.evaluate(kdf_in_e), H.evaluate(kdf_in_d)];
@@ -234,12 +196,8 @@ Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hy
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], ss, ss];
@@ -254,12 +212,8 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], ss, ss];
@@ -276,12 +230,8 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], ss, ss];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_CT.proof
@@ -195,19 +195,19 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {
         KEM_T.Ciphertext ct_T = ct[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T_0);
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(pq_keys_0[1], ct[0]);
-        KEM_T.SharedSecret ss_T = KEM_T.Decaps(t_keys[1], ct_T);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret ss_T = KEM_T.Decaps(dk, ct_T);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 
     hybrid.SharedSecret Decaps1(hybrid.Ciphertext ct) {
         KEM_T.Ciphertext ct_T = ct[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T_1);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T_1);
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(pq_keys_1[1], ct[0]);
-        KEM_T.SharedSecret ss_T = KEM_T.Decaps(t_keys[1], ct_T);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret ss_T = KEM_T.Decaps(dk, ct_T);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 
@@ -289,10 +289,10 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_seedbased hybrid)
     [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys_1;
 
     [hybrid.EncapsKey, hybrid.EncapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.EncapsKey] pq_eks = challenger.Initialize();
+        [KEM_PQ.EncapsKey, KEM_PQ.EncapsKey] [ek_PQ_0, ek_PQ_1] = challenger.Initialize();
         t_keys_0 = KEM_T.KeyGen();
         t_keys_1 = KEM_T.KeyGen();
-        return [[pq_eks[0], t_keys_0[0]], [pq_eks[1], t_keys_1[0]]];
+        return [[ek_PQ_0, t_keys_0[0]], [ek_PQ_1, t_keys_1[0]]];
     }
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {
@@ -443,19 +443,19 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {
         KEM_T.Ciphertext ct_T = ct[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T_0);
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(pq_keys_0[1], ct[0]);
-        KEM_T.SharedSecret ss_T = KEM_T.Decaps(t_keys[1], ct_T);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret ss_T = KEM_T.Decaps(dk, ct_T);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 
     hybrid.SharedSecret Decaps1(hybrid.Ciphertext ct) {
         KEM_T.Ciphertext ct_T = ct[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T_1);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T_1);
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(pq_keys_1[1], ct[0]);
-        KEM_T.SharedSecret ss_T = KEM_T.Decaps(t_keys[1], ct_T);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret ss_T = KEM_T.Decaps(dk, ct_T);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_PK.proof
@@ -194,19 +194,19 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {
         KEM_T.Ciphertext ct_T = ct[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T_0);
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(pq_keys_0[1], ct[0]);
-        KEM_T.SharedSecret ss_T = KEM_T.Decaps(t_keys[1], ct_T);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret ss_T = KEM_T.Decaps(dk, ct_T);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 
     hybrid.SharedSecret Decaps1(hybrid.Ciphertext ct) {
         KEM_T.Ciphertext ct_T = ct[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T_1);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T_1);
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(pq_keys_1[1], ct[0]);
-        KEM_T.SharedSecret ss_T = KEM_T.Decaps(t_keys[1], ct_T);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret ss_T = KEM_T.Decaps(dk, ct_T);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 
@@ -443,19 +443,19 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {
         KEM_T.Ciphertext ct_T = ct[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T_0);
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(pq_keys_0[1], ct[0]);
-        KEM_T.SharedSecret ss_T = KEM_T.Decaps(t_keys[1], ct_T);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret ss_T = KEM_T.Decaps(dk, ct_T);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 
     hybrid.SharedSecret Decaps1(hybrid.Ciphertext ct) {
         KEM_T.Ciphertext ct_T = ct[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T_1);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T_1);
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(pq_keys_1[1], ct[0]);
-        KEM_T.SharedSecret ss_T = KEM_T.Decaps(t_keys[1], ct_T);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret ss_T = KEM_T.Decaps(dk, ct_T);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_PK.proof
@@ -288,9 +288,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_seedbased hybrid)
     [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys_1;
 
     [hybrid.EncapsKey, hybrid.EncapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.EncapsKey] pq_eks = challenger.Initialize();
-        ek_PQ_0 = pq_eks[0];
-        ek_PQ_1 = pq_eks[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.EncapsKey] [ek_PQ_0, ek_PQ_1] = challenger.Initialize();
         t_keys_0 = KEM_T.KeyGen();
         t_keys_1 = KEM_T.KeyGen();
         return [[ek_PQ_0, t_keys_0[0]], [ek_PQ_1, t_keys_1[0]]];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_PQ.proof
@@ -135,12 +135,8 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
         [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
         KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -214,12 +210,8 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
         KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -285,12 +277,8 @@ Reduction R_KG_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hy
         t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -356,9 +344,7 @@ Reduction R_Correct_Real(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedba
         KEM_PQ.Ciphertext ct_PQ = corr[2];
         KEM_PQ.SharedSecret ss_PQ_e = corr[3];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -430,13 +416,9 @@ Game GameCaseSplitReal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbase
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -470,9 +452,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbas
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
@@ -508,15 +488,10 @@ Reduction RB(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [kem_ct, ct_T];
@@ -548,10 +523,7 @@ Reduction RC(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
@@ -596,9 +568,7 @@ Reduction RD(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
         kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_T.EncodeSharedSecret(ss_T), rest);
         ctStar = [kem_ct, ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_PQ.proof
@@ -148,12 +148,12 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -185,12 +185,12 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -220,12 +220,12 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 
     hybrid.SharedSecret? Decaps(hybrid.Ciphertext c) {
         if (c == ctStar) { return None; }
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -253,12 +253,12 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 
     hybrid.SharedSecret? Decaps(hybrid.Ciphertext c) {
         if (c == ctStar) { return None; }
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_T.proof
@@ -164,12 +164,8 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
         [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
         KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -240,12 +236,8 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
         KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -308,12 +300,8 @@ Reduction R_KG_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hy
         t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -383,9 +371,7 @@ Reduction R_Correct_T_Real(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seed
         KEM_T.Ciphertext ct_T = corr[2];
         KEM_T.SharedSecret ss_T_e = corr[3];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -458,12 +444,8 @@ Game G_StoredSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        ss_T_star = t_enc[0];
-        kem_ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_star) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, kem_ct_T];
@@ -501,15 +483,10 @@ Reduction R_KEM_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] ch = challenger.Initialize();
-        ek_T = ch[0];
-        ss_T_star = ch[1];
-        kem_ct_T = ch[2];
+        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_star) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, kem_ct_T];
@@ -541,10 +518,7 @@ Reduction R_KEM_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] ch = challenger.Initialize();
-        ek_T = ch[0];
-        ss_T_star = ch[1];
-        kem_ct_T = ch[2];
+        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
@@ -586,9 +560,7 @@ Game G_RandSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybri
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         ss_T_star <- BitString<KEM_T.Nss>;
@@ -636,11 +608,7 @@ Reduction R_C2PRI_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] c2pri = challenger.Initialize();
-        ek_PQ = c2pri[0];
-        dk_PQ = c2pri[1];
-        ct_PQ_star = c2pri[2];
-        ss_PQ_star = c2pri[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
@@ -684,11 +652,7 @@ Reduction R_C2PRI_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] c2pri = challenger.Initialize();
-        ek_PQ = c2pri[0];
-        dk_PQ = c2pri[1];
-        ct_PQ_star = c2pri[2];
-        ss_PQ_star = c2pri[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
@@ -738,9 +702,7 @@ Game G_Abort(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid) 
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         ss_T_star <- BitString<KEM_T.Nss>;
@@ -795,9 +757,7 @@ Reduction R_PRF_Fwd(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -839,9 +799,7 @@ Reduction R_PRF_Rev(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         kem_ct_T = _t_enc_tmp[1];
         BitString<H.Nout> ss <- BitString<H.Nout>;
@@ -887,9 +845,7 @@ Game G_AllRand(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         kem_ct_T = _t_enc_tmp[1];
         BitString<H.Nout> ss <- BitString<H.Nout>;
@@ -935,9 +891,7 @@ Game G_Unwound(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         kem_ct_T = _t_enc_tmp[1];
         ss_T_star <- BitString<KEM_T.Nss>;
@@ -1026,9 +980,7 @@ Game G_StoredSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        ss_T_star = t_enc[0];
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_T.proof
@@ -177,12 +177,12 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -214,12 +214,12 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -246,12 +246,12 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 
     hybrid.SharedSecret? Decaps(hybrid.Ciphertext c) {
         if (c == ctStar) { return None; }
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -279,12 +279,12 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
 
     hybrid.SharedSecret? Decaps(hybrid.Ciphertext c) {
         if (c == ctStar) { return None; }
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_CT.proof
@@ -183,9 +183,7 @@ Reduction R_LazyRO_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
     KEM_T.DecapsKey dk_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [BitString<lambda>, BitString<lambda>] seeds = challenger.Initialize();
-        BitString<lambda> seed_0 = seeds[0];
-        BitString<lambda> seed_1 = seeds[1];
+        [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
         [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
@@ -226,9 +224,7 @@ Reduction R_LazyRO_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
     KEM_T.DecapsKey dk_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [BitString<lambda>, BitString<lambda>] seeds = challenger.Initialize();
-        BitString<lambda> seed_0 = seeds[0];
-        BitString<lambda> seed_1 = seeds[1];
+        [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
         [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
@@ -272,12 +268,8 @@ Reduction R_KG_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = challenger.Generate();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = challenger.Generate();
-        KEM_PQ.EncapsKey ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        KEM_PQ.EncapsKey ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = challenger.Generate();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
@@ -332,12 +324,8 @@ Reduction R_KG_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = challenger.Generate();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = challenger.Generate();
-        KEM_PQ.EncapsKey ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        KEM_PQ.EncapsKey ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = challenger.Generate();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
@@ -391,11 +379,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Initialize();
-        KEM_PQ.EncapsKey ek_PQ_0 = pq_keys[0];
-        s_PQ_0 = pq_keys[1];
-        KEM_PQ.EncapsKey ek_PQ_1 = pq_keys[2];
-        s_PQ_1 = pq_keys[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, s_PQ_0, ek_PQ_1, s_PQ_1] = challenger.Initialize();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_CT.proof
@@ -185,13 +185,11 @@ Reduction R_LazyRO_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
         [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_1  = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         dk_PQ_0 = pq_kp_0[1];
         dk_PQ_1 = pq_kp_1[1];
-        ek_T_0  = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1  = t_kp_1[0]; dk_T_1 = t_kp_1[1];
         return [[pq_kp_0[0], ek_T_0], seed_0, [pq_kp_1[0], ek_T_1], seed_1];
     }
 
@@ -226,13 +224,11 @@ Reduction R_LazyRO_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
         [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_1  = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         dk_PQ_0 = pq_kp_0[1];
         dk_PQ_1 = pq_kp_1[1];
-        ek_T_0  = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1  = t_kp_1[0]; dk_T_1 = t_kp_1[1];
         return [[pq_kp_0[0], ek_T_0], seed_0, [pq_kp_1[0], ek_T_1], seed_1];
     }
 
@@ -274,10 +270,8 @@ Reduction R_KG_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
         s_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(s_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(s_T_1);
-        ek_T_0 = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1 = t_kp_1[0]; dk_T_1 = t_kp_1[1];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(s_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(s_T_1);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 
@@ -330,10 +324,8 @@ Reduction R_KG_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
         s_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(s_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(s_T_1);
-        ek_T_0 = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1 = t_kp_1[0]; dk_T_1 = t_kp_1[1];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(s_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(s_T_1);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 
@@ -384,10 +376,8 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, Int lambda,
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
         s_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(s_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(s_T_1);
-        ek_T_0 = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1 = t_kp_1[0]; dk_T_1 = t_kp_1[1];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(s_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(s_T_1);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 
@@ -455,14 +445,10 @@ Reduction R_KDF(KEM KEM_PQ, KEM KEM_T, Int lambda,
         s_PQ_1 <- BitString<KEM_PQ.Nseed>;
         s_T_0 <- BitString<KEM_T.Nseed>;
         s_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(s_PQ_0);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(s_PQ_1);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(s_T_0);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_1  = KEM_T.DeriveKeyPair(s_T_1);
-        ek_PQ_0 = pq_kp_0[0]; dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0]; dk_PQ_1 = pq_kp_1[1];
-        ek_T_0  = t_kp_0[0];  dk_T_0  = t_kp_0[1];
-        ek_T_1  = t_kp_1[0];  dk_T_1  = t_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.DeriveKeyPair(s_PQ_0);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.DeriveKeyPair(s_PQ_1);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(s_T_0);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(s_T_1);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_PK.proof
@@ -185,14 +185,10 @@ Reduction R_LazyRO_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
         [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_1  = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
-        ek_PQ_0 = pq_kp_0[0]; dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0]; dk_PQ_1 = pq_kp_1[1];
-        ek_T_0  = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1  = t_kp_1[0]; dk_T_1 = t_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 
@@ -230,14 +226,10 @@ Reduction R_LazyRO_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
         [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_1  = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
-        ek_PQ_0 = pq_kp_0[0]; dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0]; dk_PQ_1 = pq_kp_1[1];
-        ek_T_0  = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1  = t_kp_1[0]; dk_T_1 = t_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 
@@ -282,10 +274,8 @@ Reduction R_KG_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
         s_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(s_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(s_T_1);
-        ek_T_0 = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1 = t_kp_1[0]; dk_T_1 = t_kp_1[1];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(s_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(s_T_1);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 
@@ -342,10 +332,8 @@ Reduction R_KG_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
         s_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(s_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(s_T_1);
-        ek_T_0 = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1 = t_kp_1[0]; dk_T_1 = t_kp_1[1];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(s_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(s_T_1);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 
@@ -400,10 +388,8 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, Int lambda,
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
         s_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(s_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(s_T_1);
-        ek_T_0 = t_kp_0[0]; dk_T_0 = t_kp_0[1];
-        ek_T_1 = t_kp_1[0]; dk_T_1 = t_kp_1[1];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(s_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(s_T_1);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 
@@ -473,14 +459,10 @@ Reduction R_KDF(KEM KEM_PQ, KEM KEM_T, Int lambda,
         s_PQ_1 <- BitString<KEM_PQ.Nseed>;
         s_T_0 <- BitString<KEM_T.Nseed>;
         s_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(s_PQ_0);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(s_PQ_1);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(s_T_0);
-        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_1  = KEM_T.DeriveKeyPair(s_T_1);
-        ek_PQ_0 = pq_kp_0[0]; dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0]; dk_PQ_1 = pq_kp_1[1];
-        ek_T_0  = t_kp_0[0];  dk_T_0  = t_kp_0[1];
-        ek_T_1  = t_kp_1[0];  dk_T_1  = t_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.DeriveKeyPair(s_PQ_0);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.DeriveKeyPair(s_PQ_1);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(s_T_0);
+        [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(s_T_1);
         return [[ek_PQ_0, ek_T_0], seed_0, [ek_PQ_1, ek_T_1], seed_1];
     }
 

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_PK.proof
@@ -184,9 +184,7 @@ Reduction R_LazyRO_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
     KEM_T.DecapsKey dk_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [BitString<lambda>, BitString<lambda>] seeds = challenger.Initialize();
-        BitString<lambda> seed_0 = seeds[0];
-        BitString<lambda> seed_1 = seeds[1];
+        [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
         [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
@@ -231,9 +229,7 @@ Reduction R_LazyRO_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
     KEM_T.DecapsKey dk_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [BitString<lambda>, BitString<lambda>] seeds = challenger.Initialize();
-        BitString<lambda> seed_0 = seeds[0];
-        BitString<lambda> seed_1 = seeds[1];
+        [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
         [KEM_T.EncapsKey,  KEM_T.DecapsKey]  t_kp_0  = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
@@ -280,12 +276,8 @@ Reduction R_KG_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = challenger.Generate();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = challenger.Generate();
-        ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = challenger.Generate();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
@@ -344,12 +336,8 @@ Reduction R_KG_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = challenger.Generate();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = challenger.Generate();
-        ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = challenger.Generate();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;
@@ -407,11 +395,7 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, Int lambda,
     BitString<lambda> seed_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Initialize();
-        ek_PQ_0 = pq_keys[0];
-        s_PQ_0 = pq_keys[1];
-        ek_PQ_1 = pq_keys[2];
-        s_PQ_1 = pq_keys[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, s_PQ_0, ek_PQ_1, s_PQ_1] = challenger.Initialize();
         seed_0 <- BitString<lambda>;
         seed_1 <-uniq[{seed_0}] BitString<lambda>;
         s_T_0 <- BitString<KEM_T.Nseed>;

--- a/applications/cfrg-hybrid-kems/proofs/Generic/LEAK_implies_HON_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/Generic/LEAK_implies_HON_BIND_K_CT.proof
@@ -53,10 +53,8 @@ Reduction R(KEM K) compose LEAK_BIND_K_CT(K) against HON_BIND_K_CT(K).Adversary 
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.EncapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] keys = challenger.Initialize();
-        dk0 = keys[1];
-        dk1 = keys[3];
-        return [keys[0], keys[2]];
+        [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] [ek0, dk0, ek1, dk1] = challenger.Initialize();
+        return [ek0, ek1];
     }
 
     K.SharedSecret Decaps0(K.Ciphertext ct) {

--- a/applications/cfrg-hybrid-kems/proofs/Generic/LEAK_implies_HON_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/Generic/LEAK_implies_HON_BIND_K_PK.proof
@@ -54,10 +54,8 @@ Reduction R(KEM K) compose LEAK_BIND_K_PK(K) against HON_BIND_K_PK(K).Adversary 
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.EncapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] keys = challenger.Initialize();
-        dk0 = keys[1];
-        dk1 = keys[3];
-        return [keys[0], keys[2]];
+        [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] [ek0, dk0, ek1, dk1] = challenger.Initialize();
+        return [ek0, ek1];
     }
 
     K.SharedSecret Decaps0(K.Ciphertext ct) {

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_Correctness.proof
@@ -72,11 +72,7 @@ games:
 Reduction R_KEM_PQ(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, UG_expanded hybrid)
     compose KEMCorrectness(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] pq_result = challenger.Compute();
-        KEM_PQ.EncapsKey ek_PQ = pq_result[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_result[1];
-        KEM_PQ.SharedSecret ss_PQ_e = pq_result[2];
-        KEM_PQ.SharedSecret ss_PQ_d = pq_result[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] [ek_PQ, ct_PQ, ss_PQ_e, ss_PQ_d] = challenger.Compute();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -100,9 +96,7 @@ Reduction R_NG(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, UG_expanded hybrid)
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_INDCCA_PQ.proof
@@ -194,9 +194,7 @@ Game GameCaseSplitReal(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_ex
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -237,9 +235,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_e
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -277,10 +273,7 @@ Reduction RB(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_expanded hyb
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -320,10 +313,7 @@ Reduction RC(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_expanded hyb
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_INDCCA_T.proof
@@ -125,15 +125,11 @@ Reduction R_Dist_Real(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_expanded h
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Scalar, NG.Scalar] dist = challenger.Initialize();
-        dk_T = dist[0];
-        NG.Scalar sk_E = dist[1];
+        [NG.Scalar, NG.Scalar] [dk_T, sk_E] = challenger.Initialize();
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<NG.Nss> ss_T = NG.ElementToSharedSecret(NG.Exp(ek_T, sk_E));
         BitString<hybrid.Nin> kdf_in =
@@ -166,9 +162,7 @@ Reduction R_Dist_Random(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_expanded
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Scalar, NG.Scalar] dist = challenger.Initialize();
-        dk_T = dist[0];
-        NG.Scalar sk_E = dist[1];
+        [NG.Scalar, NG.Scalar] [dk_T, sk_E] = challenger.Initialize();
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
@@ -203,14 +197,10 @@ Reduction R_Wrap_Prog(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G, La
     compose LazyROTwoViewsExcludedProgrammed(P, hybrid.Nss) against KEM_INDCCA_ROM(hybrid, BitString<hybrid.Nin>, BitString<hybrid.Nss>, H).Adversary {
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Scalar sk_E <- NG.Scalar;
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<NG.Nss> ss_T = NG.ElementToSharedSecret(NG.Exp(ek_T, sk_E));
@@ -238,9 +228,7 @@ Reduction R_Wrap_NoAbort(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G,
     compose LazyROTwoViewsExcluded(P, hybrid.Nss) against KEM_INDCCA_ROM(hybrid, BitString<hybrid.Nin>, BitString<hybrid.Nss>, H).Adversary {
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
@@ -276,15 +264,9 @@ Reduction R_Combined(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_expanded hy
     Map<[KEM_PQ.Ciphertext, NG.Element], BitString<hybrid.Nss>> QT;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Element, NG.Element] chal = challenger.Initialize();
-        ek_T = chal[0];
-        NG.Element ct_T = chal[1];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        ek_PQ = pq_keys[0];
-        dk_PQ = pq_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [NG.Element, NG.Element] [ek_T, ct_T] = challenger.Initialize();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         ctStar = [ct_PQ, ct_T];
         ss_star <- BitString<hybrid.Nss>;
         return [[ek_PQ, ek_T], ss_star, ctStar];
@@ -333,9 +315,7 @@ Reduction R_Combined(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_expanded hy
         }
         if (m in HT) { return HT[m]; }
         for ([[KEM_PQ.Ciphertext, NG.Element], BitString<hybrid.Nss>] e in QT.entries) {
-            [KEM_PQ.Ciphertext, NG.Element] c_key = e[0];
-            KEM_PQ.Ciphertext c_PQ = c_key[0];
-            NG.Element c_T = c_key[1];
+            [KEM_PQ.Ciphertext, NG.Element] [c_PQ, c_T] = e[0];
             KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(dk_PQ, c_PQ);
             if (m[0 : KEM_PQ.Nss] == KEM_PQ.EncodeSharedSecret(ss_PQ)
                 && challenger.DH(c_T, ss_T_slot)

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_Correctness.proof
@@ -111,14 +111,10 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
         BitString<G.lambda + G.stretch> seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -134,15 +130,11 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
 Reduction R_KG_PQ_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hybrid)
     compose KeyGenEquiv(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = challenger.Generate();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -160,11 +152,7 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedb
 Reduction R_KEM_PQ(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hybrid)
     compose KEMCorrectness(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] pq_result = challenger.Compute();
-        KEM_PQ.EncapsKey ek_PQ = pq_result[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_result[1];
-        KEM_PQ.SharedSecret ss_PQ_e = pq_result[2];
-        KEM_PQ.SharedSecret ss_PQ_d = pq_result[3];
+        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] [ek_PQ, ct_PQ, ss_PQ_e, ss_PQ_d] = challenger.Compute();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -192,9 +180,7 @@ Reduction R_NG(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased 
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -219,9 +205,7 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedb
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -242,9 +226,7 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_PQ.proof
@@ -138,13 +138,13 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek, dk] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         NG.Element c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk, c1);
         BitString<NG.Nss> dec_ss_T = NG.ElementToSharedSecret(NG.Exp(c2, dk_T));
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || KEM_PQ.EncodeCiphertext(c1) || NG.Encode(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || KEM_PQ.EncodeCiphertext(c1) || NG.Encode(c2) || KEM_PQ.EncodeEncapsKey(ek) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -176,13 +176,13 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek, dk] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         NG.Element c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk, c1);
         BitString<NG.Nss> dec_ss_T = NG.ElementToSharedSecret(NG.Exp(c2, dk_T));
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || KEM_PQ.EncodeCiphertext(c1) || NG.Encode(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || KEM_PQ.EncodeCiphertext(c1) || NG.Encode(c2) || KEM_PQ.EncodeEncapsKey(ek) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
         return H.evaluate(kdf_in);
     }
 }

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_PQ.proof
@@ -123,9 +123,7 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
         KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -205,9 +203,7 @@ Reduction R_KG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbase
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -363,9 +359,7 @@ Game GameCaseSplitReal(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_se
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -406,9 +400,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_s
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -446,10 +438,7 @@ Reduction RB(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hy
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -489,10 +478,7 @@ Reduction RC(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hy
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_T.proof
@@ -163,14 +163,14 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased hybr
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek, dk] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         NG.Element c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk, c1);
         BitString<NG.Nss> dec_ss_T = NG.ElementToSharedSecret(NG.Exp(c2, dk_T));
         BitString<hybrid.Nin> kdf_in =
-            KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || KEM_PQ.EncodeCiphertext(c1) || NG.Encode(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
+            KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || KEM_PQ.EncodeCiphertext(c1) || NG.Encode(c2) || KEM_PQ.EncodeEncapsKey(ek) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
         return H(kdf_in);
     }
 
@@ -206,14 +206,14 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased hybr
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek, dk] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         NG.Element c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk, c1);
         BitString<NG.Nss> dec_ss_T = NG.ElementToSharedSecret(NG.Exp(c2, dk_T));
         BitString<hybrid.Nin> kdf_in =
-            KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || KEM_PQ.EncodeCiphertext(c1) || NG.Encode(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
+            KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || KEM_PQ.EncodeCiphertext(c1) || NG.Encode(c2) || KEM_PQ.EncodeEncapsKey(ek) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
         return H(kdf_in);
     }
 

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_T.proof
@@ -147,9 +147,7 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased hybr
         KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -239,9 +237,7 @@ Reduction R_KG_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased hybri
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -319,15 +315,11 @@ Reduction R_Dist_Real(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased 
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Scalar, NG.Scalar] dist = challenger.Initialize();
-        dk_T = dist[0];
-        NG.Scalar sk_E = dist[1];
+        [NG.Scalar, NG.Scalar] [dk_T, sk_E] = challenger.Initialize();
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<NG.Nss> ss_T = NG.ElementToSharedSecret(NG.Exp(ek_T, sk_E));
         BitString<hybrid.Nin> kdf_in =
@@ -360,9 +352,7 @@ Reduction R_Dist_Random(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbase
     [KEM_PQ.Ciphertext, NG.Element] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Scalar, NG.Scalar] dist = challenger.Initialize();
-        dk_T = dist[0];
-        NG.Scalar sk_E = dist[1];
+        [NG.Scalar, NG.Scalar] [dk_T, sk_E] = challenger.Initialize();
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
@@ -397,14 +387,10 @@ Reduction R_Wrap_Prog(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G, La
     compose LazyROTwoViewsExcludedProgrammed(P, hybrid.Nss) against KEM_INDCCA_ROM(hybrid, BitString<hybrid.Nin>, BitString<hybrid.Nss>, H).Adversary {
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Scalar sk_E <- NG.Scalar;
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<NG.Nss> ss_T = NG.ElementToSharedSecret(NG.Exp(ek_T, sk_E));
@@ -432,9 +418,7 @@ Reduction R_Wrap_NoAbort(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G,
     compose LazyROTwoViewsExcluded(P, hybrid.Nss) against KEM_INDCCA_ROM(hybrid, BitString<hybrid.Nin>, BitString<hybrid.Nss>, H).Adversary {
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
@@ -470,15 +454,9 @@ Reduction R_Combined(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased h
     Map<[KEM_PQ.Ciphertext, NG.Element], BitString<hybrid.Nss>> QT;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [NG.Element, NG.Element] chal = challenger.Initialize();
-        ek_T = chal[0];
-        NG.Element ct_T = chal[1];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        ek_PQ = pq_keys[0];
-        dk_PQ = pq_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ_star = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [NG.Element, NG.Element] [ek_T, ct_T] = challenger.Initialize();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         ctStar = [ct_PQ, ct_T];
         ss_star <- BitString<hybrid.Nss>;
         return [[ek_PQ, ek_T], ss_star, ctStar];
@@ -527,9 +505,7 @@ Reduction R_Combined(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased h
         }
         if (m in HT) { return HT[m]; }
         for ([[KEM_PQ.Ciphertext, NG.Element], BitString<hybrid.Nss>] e in QT.entries) {
-            [KEM_PQ.Ciphertext, NG.Element] c_key = e[0];
-            KEM_PQ.Ciphertext c_PQ = c_key[0];
-            NG.Element c_T = c_key[1];
+            [KEM_PQ.Ciphertext, NG.Element] [c_PQ, c_T] = e[0];
             KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(dk_PQ, c_PQ);
             if (m[0 : KEM_PQ.Nss] == KEM_PQ.EncodeSharedSecret(ss_PQ)
                 && challenger.DH(c_T, ss_T_slot)

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_Correctness.proof
@@ -69,17 +69,9 @@ games:
 Reduction R_KEM_PQ(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, UK_expanded hybrid)
     compose KEMCorrectness(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] pq_result = challenger.Compute();
-        KEM_PQ.EncapsKey ek_PQ = pq_result[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_result[1];
-        KEM_PQ.SharedSecret ss_PQ_e = pq_result[2];
-        KEM_PQ.SharedSecret ss_PQ_d = pq_result[3];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.KeyGen();
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] [ek_PQ, ct_PQ, ss_PQ_e, ss_PQ_d] = challenger.Compute();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.KeyGen();
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ_d) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -90,16 +82,10 @@ Reduction R_KEM_PQ(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, UK_expanded hybrid)
 Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, UK_expanded hybrid)
     compose KEMCorrectness(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] t_result = challenger.Compute();
-        KEM_T.EncapsKey ek_T = t_result[0];
-        KEM_T.Ciphertext ct_T = t_result[1];
-        KEM_T.SharedSecret ss_T_e = t_result[2];
-        KEM_T.SharedSecret ss_T_d = t_result[3];
+        [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] [ek_T, ct_T, ss_T_e, ss_T_d] = challenger.Compute();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], H.evaluate(kdf_in_e), H.evaluate(kdf_in_d)];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_INDCCA_PQ.proof
@@ -102,9 +102,7 @@ Reduction R_Correct_Real(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expand
         KEM_PQ.Ciphertext ct_PQ = corr[2];
         KEM_PQ.SharedSecret ss_PQ_e = corr[3];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -175,13 +173,9 @@ Game GameCaseSplitReal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -215,9 +209,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expande
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
@@ -253,15 +245,10 @@ Reduction RB(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid)
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(kem_ct) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [kem_ct, ct_T];
@@ -293,10 +280,7 @@ Reduction RC(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid)
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
@@ -340,9 +324,7 @@ Reduction RD(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid)
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
         kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_PQ.EncodeCiphertext(kem_ct) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_T.EncodeSharedSecret(ss_T), rest);
         ctStar = [kem_ct, ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_INDCCA_T.proof
@@ -110,9 +110,7 @@ Reduction R_Correct_T_Real(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expa
         KEM_T.Ciphertext ct_T = corr[2];
         KEM_T.SharedSecret ss_T_e = corr[3];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -183,12 +181,8 @@ Game G_StoredSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybr
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        ss_T_star = t_enc[0];
-        kem_ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_star) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, kem_ct_T];
@@ -222,15 +216,10 @@ Reduction R_KEM_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hy
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] ch = challenger.Initialize();
-        ek_T = ch[0];
-        ss_T_star = ch[1];
-        kem_ct_T = ch[2];
+        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_star) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, kem_ct_T];
@@ -262,10 +251,7 @@ Reduction R_KEM_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hy
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] ch = challenger.Initialize();
-        ek_T = ch[0];
-        ss_T_star = ch[1];
-        kem_ct_T = ch[2];
+        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
@@ -306,9 +292,7 @@ Game G_RandSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         ss_T_star <- BitString<KEM_T.Nss>;
@@ -349,9 +333,7 @@ Reduction R_PRF_Fwd(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hy
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -509,9 +491,7 @@ Game G_StoredSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hy
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        ss_T_star = t_enc[0];
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_Correctness.proof
@@ -114,18 +114,10 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         BitString<G.lambda + G.stretch> seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_PQ.SharedSecret ss_PQ_d = KEM_PQ.Decaps(dk_PQ, ct_PQ);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -137,19 +129,11 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
 Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     compose KeyGenEquiv(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = challenger.Generate();
         BitString<KEM_T.Nseed> seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_PQ.SharedSecret ss_PQ_d = KEM_PQ.Decaps(dk_PQ, ct_PQ);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -161,18 +145,10 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
 Reduction R_KG_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     compose KeyGenEquiv(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = challenger.Generate();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keys[1];
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ_e = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = challenger.Generate();
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_e, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_PQ.SharedSecret ss_PQ_d = KEM_PQ.Decaps(dk_PQ, ct_PQ);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -185,17 +161,9 @@ Reduction R_KG_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hy
 Reduction R_KEM_PQ(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     compose KEMCorrectness(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] pq_result = challenger.Compute();
-        KEM_PQ.EncapsKey ek_PQ = pq_result[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_result[1];
-        KEM_PQ.SharedSecret ss_PQ_e = pq_result[2];
-        KEM_PQ.SharedSecret ss_PQ_d = pq_result[3];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.KeyGen();
-        KEM_T.EncapsKey ek_T = t_keys[0];
-        KEM_T.DecapsKey dk_T = t_keys[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T_e = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret, KEM_PQ.SharedSecret] [ek_PQ, ct_PQ, ss_PQ_e, ss_PQ_d] = challenger.Compute();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.KeyGen();
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_e, ct_T] = KEM_T.Encaps(ek_T);
         KEM_T.SharedSecret ss_T_d = KEM_T.Decaps(dk_T, ct_T);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ_d) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -206,16 +174,10 @@ Reduction R_KEM_PQ(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hy
 Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     compose KEMCorrectness(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] t_result = challenger.Compute();
-        KEM_T.EncapsKey ek_T = t_result[0];
-        KEM_T.Ciphertext ct_T = t_result[1];
-        KEM_T.SharedSecret ss_T_e = t_result[2];
-        KEM_T.SharedSecret ss_T_d = t_result[3];
+        [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] [ek_T, ct_T, ss_T_e, ss_T_d] = challenger.Compute();
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], H.evaluate(kdf_in_e), H.evaluate(kdf_in_d)];
@@ -231,12 +193,8 @@ Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hy
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], ss, ss];
@@ -251,12 +209,8 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], ss, ss];
@@ -273,12 +227,8 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         return [[ek_PQ, ek_T], [ct_PQ, ct_T], ss, ss];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_PQ.proof
@@ -227,12 +227,12 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
 
     hybrid.SharedSecret? Decaps(hybrid.Ciphertext c) {
         if (c == ctStar) { return None; }
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -260,12 +260,12 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
 
     hybrid.SharedSecret? Decaps(hybrid.Ciphertext c) {
         if (c == ctStar) { return None; }
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_PQ.proof
@@ -142,12 +142,8 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
         [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
         KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -221,12 +217,8 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
         KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -292,12 +284,8 @@ Reduction R_KG_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hy
         t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -363,9 +351,7 @@ Reduction R_Correct_Real(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedba
         KEM_PQ.Ciphertext ct_PQ = corr[2];
         KEM_PQ.SharedSecret ss_PQ_e = corr[3];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ_e) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -437,13 +423,9 @@ Game GameCaseSplitReal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbase
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -477,9 +459,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbas
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        ss_PQ = pq_enc[0];
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
         KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
@@ -515,15 +495,10 @@ Reduction RB(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(kem_ct) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [kem_ct, ct_T];
@@ -555,10 +530,7 @@ Reduction RC(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] ch = challenger.Initialize();
-        ek_PQ = ch[0];
-        ss_PQ = ch[1];
-        kem_ct = ch[2];
+        [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
@@ -603,9 +575,7 @@ Reduction RD(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
         kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_PQ.EncodeCiphertext(kem_ct) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_T.EncodeSharedSecret(ss_T), rest);
         ctStar = [kem_ct, ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_T.proof
@@ -149,12 +149,8 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
         [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
         KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -225,12 +221,8 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
         KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -293,12 +285,8 @@ Reduction R_KG_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hy
         t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -367,9 +355,7 @@ Reduction R_Correct_T_Real(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seed
         KEM_T.Ciphertext ct_T = corr[2];
         KEM_T.SharedSecret ss_T_e = corr[3];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, ct_T];
@@ -442,12 +428,8 @@ Game G_StoredSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        ss_T_star = t_enc[0];
-        kem_ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_star) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, kem_ct_T];
@@ -485,15 +467,10 @@ Reduction R_KEM_T_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] ch = challenger.Initialize();
-        ek_T = ch[0];
-        ss_T_star = ch[1];
-        kem_ct_T = ch[2];
+        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_star) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
         ctStar = [ct_PQ, kem_ct_T];
@@ -525,10 +502,7 @@ Reduction R_KEM_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
     [KEM_PQ.Ciphertext, KEM_T.Ciphertext] ctStar;
 
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
-        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] ch = challenger.Initialize();
-        ek_T = ch[0];
-        ss_T_star = ch[1];
-        kem_ct_T = ch[2];
+        [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
@@ -570,9 +544,7 @@ Game G_RandSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybri
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         ss_T_star <- BitString<KEM_T.Nss>;
@@ -622,9 +594,7 @@ Reduction R_PRF_Fwd(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
         kem_ct_T = t_enc[1];
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -789,9 +759,7 @@ Game G_StoredSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        ss_T_star = t_enc[0];
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_T.proof
@@ -231,12 +231,12 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
 
     hybrid.SharedSecret? Decaps(hybrid.Ciphertext c) {
         if (c == ctStar) { return None; }
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -264,12 +264,12 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
 
     hybrid.SharedSecret? Decaps(hybrid.Ciphertext c) {
         if (c == ctStar) { return None; }
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
         KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
     }
 }

--- a/applications/cfrg-hybrid-kems/schemes/CG/CG_expanded.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/CG/CG_expanded.scheme
@@ -51,9 +51,7 @@ Scheme CG_expanded(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(seed);
         BitString<K.Nseed> seed_PQ = seed_full[0 : K.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[K.Nseed : K.Nseed + NG.Nseed];
-        [K.EncapsKey, K.DecapsKey] kem_keypair = K.DeriveKeyPair(seed_PQ);
-        K.EncapsKey ek_PQ = kem_keypair[0];
-        K.DecapsKey dk_PQ = kem_keypair[1];
+        [K.EncapsKey, K.DecapsKey] [ek_PQ, dk_PQ] = K.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         return [[ek_PQ, ek_T], [dk_PQ, dk_T, ek_T]];
@@ -62,9 +60,7 @@ Scheme CG_expanded(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
     // Expanded-form KeyGen: K.KeyGen() called directly for the PQ side,
     // and the trans-side scalar is derived from a freshly sampled seed.
     [EncapsKey, DecapsKey] KeyGen() {
-        [K.EncapsKey, K.DecapsKey] kem_keypair = K.KeyGen();
-        K.EncapsKey ek_PQ = kem_keypair[0];
-        K.DecapsKey dk_PQ = kem_keypair[1];
+        [K.EncapsKey, K.DecapsKey] [ek_PQ, dk_PQ] = K.KeyGen();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -75,9 +71,7 @@ Scheme CG_expanded(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
     [SharedSecret, Ciphertext] Encaps(EncapsKey ek) {
         K.EncapsKey ek_PQ = ek[0];
         NG.Element ek_T = ek[1];
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(ek_PQ);
-        K.SharedSecret ss_PQ = encaps_result[0];
-        K.Ciphertext ct_PQ = encaps_result[1];
+        [K.SharedSecret, K.Ciphertext] [ss_PQ, ct_PQ] = K.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/schemes/CG/CG_seedbased.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/CG/CG_seedbased.scheme
@@ -90,9 +90,7 @@ Scheme CG_seedbased(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
     [SharedSecret, Ciphertext] Encaps(EncapsKey ek) {
         K.EncapsKey ek_PQ = ek[0];
         NG.Element ek_T = ek[1];
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(ek_PQ);
-        K.SharedSecret ss_PQ = encaps_result[0];
-        K.Ciphertext ct_PQ = encaps_result[1];
+        [K.SharedSecret, K.Ciphertext] [ss_PQ, ct_PQ] = K.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/schemes/CK/CK_expanded.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/CK/CK_expanded.scheme
@@ -62,12 +62,8 @@ Scheme CK_expanded(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
     [SharedSecret, Ciphertext] Encaps(EncapsKey ek) {
         KEM_PQ.EncapsKey ek_PQ = ek[0];
         KEM_T.EncapsKey ek_T = ek[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         SharedSecret ss = H.evaluate(kdf_in);
         return [ss, [ct_PQ, ct_T]];

--- a/applications/cfrg-hybrid-kems/schemes/CK/CK_seedbased.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/CK/CK_seedbased.scheme
@@ -80,12 +80,8 @@ Scheme CK_seedbased(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
     [SharedSecret, Ciphertext] Encaps(EncapsKey ek) {
         KEM_PQ.EncapsKey ek_PQ = ek[0];
         KEM_T.EncapsKey ek_T = ek[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         SharedSecret ss = H.evaluate(kdf_in);
         return [ss, [ct_PQ, ct_T]];
@@ -123,10 +119,8 @@ Scheme CK_seedbased(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keypair = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.DecapsKey dk_PQ = pq_keypair[1];
-        KEM_T.EncapsKey ek_T = t_keypair[0];
-        KEM_T.DecapsKey dk_T = t_keypair[1];
         KEM_PQ.Ciphertext ct_PQ = ct[0];
         KEM_T.Ciphertext ct_T = ct[1];
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(dk_PQ, ct_PQ);

--- a/applications/cfrg-hybrid-kems/schemes/UG/UG_expanded.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/UG/UG_expanded.scheme
@@ -51,9 +51,7 @@ Scheme UG_expanded(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(seed);
         BitString<K.Nseed> seed_PQ = seed_full[0 : K.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[K.Nseed : K.Nseed + NG.Nseed];
-        [K.EncapsKey, K.DecapsKey] kem_keypair = K.DeriveKeyPair(seed_PQ);
-        K.EncapsKey ek_PQ = kem_keypair[0];
-        K.DecapsKey dk_PQ = kem_keypair[1];
+        [K.EncapsKey, K.DecapsKey] [ek_PQ, dk_PQ] = K.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         return [[ek_PQ, ek_T], [dk_PQ, ek_PQ, dk_T, ek_T]];
@@ -62,9 +60,7 @@ Scheme UG_expanded(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
     // Expanded-form KeyGen: K.KeyGen() called directly for the PQ side,
     // and the trans-side scalar is derived from a freshly sampled seed.
     [EncapsKey, DecapsKey] KeyGen() {
-        [K.EncapsKey, K.DecapsKey] kem_keypair = K.KeyGen();
-        K.EncapsKey ek_PQ = kem_keypair[0];
-        K.DecapsKey dk_PQ = kem_keypair[1];
+        [K.EncapsKey, K.DecapsKey] [ek_PQ, dk_PQ] = K.KeyGen();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
@@ -75,9 +71,7 @@ Scheme UG_expanded(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
     [SharedSecret, Ciphertext] Encaps(EncapsKey ek) {
         K.EncapsKey ek_PQ = ek[0];
         NG.Element ek_T = ek[1];
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(ek_PQ);
-        K.SharedSecret ss_PQ = encaps_result[0];
-        K.Ciphertext ct_PQ = encaps_result[1];
+        [K.SharedSecret, K.Ciphertext] [ss_PQ, ct_PQ] = K.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/schemes/UG/UG_seedbased.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/UG/UG_seedbased.scheme
@@ -88,9 +88,7 @@ Scheme UG_seedbased(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
     [SharedSecret, Ciphertext] Encaps(EncapsKey ek) {
         K.EncapsKey ek_PQ = ek[0];
         NG.Element ek_T = ek[1];
-        [K.SharedSecret, K.Ciphertext] encaps_result = K.Encaps(ek_PQ);
-        K.SharedSecret ss_PQ = encaps_result[0];
-        K.Ciphertext ct_PQ = encaps_result[1];
+        [K.SharedSecret, K.Ciphertext] [ss_PQ, ct_PQ] = K.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -133,9 +131,7 @@ Scheme UG_seedbased(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(dk);
         BitString<K.Nseed> seed_PQ = seed_full[0 : K.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[K.Nseed : K.Nseed + NG.Nseed];
-        [K.EncapsKey, K.DecapsKey] kem_keypair = K.DeriveKeyPair(seed_PQ);
-        K.EncapsKey ek_PQ = kem_keypair[0];
-        K.DecapsKey dk_PQ = kem_keypair[1];
+        [K.EncapsKey, K.DecapsKey] [ek_PQ, dk_PQ] = K.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         K.Ciphertext ct_PQ = ct[0];

--- a/applications/cfrg-hybrid-kems/schemes/UK/UK_expanded.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/UK/UK_expanded.scheme
@@ -66,12 +66,8 @@ Scheme UK_expanded(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
     [SharedSecret, Ciphertext] Encaps(EncapsKey ek) {
         KEM_PQ.EncapsKey ek_PQ = ek[0];
         KEM_T.EncapsKey ek_T = ek[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         SharedSecret ss = H.evaluate(kdf_in);
         return [ss, [ct_PQ, ct_T]];

--- a/applications/cfrg-hybrid-kems/schemes/UK/UK_seedbased.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/UK/UK_seedbased.scheme
@@ -78,12 +78,8 @@ Scheme UK_seedbased(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
     [SharedSecret, Ciphertext] Encaps(EncapsKey ek) {
         KEM_PQ.EncapsKey ek_PQ = ek[0];
         KEM_T.EncapsKey ek_T = ek[1];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        KEM_PQ.SharedSecret ss_PQ = pq_enc[0];
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
-        KEM_T.SharedSecret ss_T = t_enc[0];
-        KEM_T.Ciphertext ct_T = t_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         SharedSecret ss = H.evaluate(kdf_in);
         return [ss, [ct_PQ, ct_T]];
@@ -120,12 +116,8 @@ Scheme UK_seedbased(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(dk);
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keypair = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keypair[0];
-        KEM_PQ.DecapsKey dk_PQ = pq_keypair[1];
-        KEM_T.EncapsKey ek_T = t_keypair[0];
-        KEM_T.DecapsKey dk_T = t_keypair[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext ct_PQ = ct[0];
         KEM_T.Ciphertext ct_T = ct[1];
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(dk_PQ, ct_PQ);


### PR DESCRIPTION
Rewrites the common "bind a tuple, then pull out each component by index" pattern into a single destructuring binding throughout the example corpus.

```
[E.PublicKey, E.SecretKey] k = E.KeyGen();
pk = k[0];
sk = k[1];
```

becomes

```
[E.PublicKey, E.SecretKey] [pk, sk] = E.KeyGen();
```

The rewrite covers three shapes: elements bound to their own named variables; elements used inline in later expressions (given a name derived from the element type — `pk`/`sk`/`ss`/`ct`/`ek`/`dk`); and tuples whose components share a type, named by hand (anonymous group elements as `x`/`y`/`z`, key material following the local `_PQ_0`/`_PQ_1` convention).

**Scope:** 86 files, ~1100 fewer lines, spanning the KEM/PubKeyEnc/Group games and proofs and the `cfrg-hybrid-kems`, `KEMCombiner-GHP18`, and `StarHunters-COSS26` applications.

### Compatibility

This depends on the FrogLang parser change that adds destructuring-binding syntax. These files will **not parse** with a ProofFrog build that predates that change, so the submodule pointer should only be advanced together with a tooling version that understands the new form.

### Behaviour

Purely a surface change. The parser desugars each destructuring binding back into the original temp-bind-plus-element-reads, so every game, scheme, reduction, and proof behaves exactly as before; all example proofs continue to verify.

### Left as-is

- Product-typed *parameters*, which can't be destructured.
- A few bindings that re-declare a component under a different type alias, where destructuring would change the declared type.
- Tuples of repeated types with no clear distinct names beyond the cases handled above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
