### PR TITLE
refactor(cfrg-hybrid-kems): use tuple destructuring for key/encaps bindings

### DIFF
--- a/applications/cfrg-hybrid-kems/games/KEM/Binding/HON_BIND_K_CT.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/Binding/HON_BIND_K_CT.game
@@ -30,11 +30,9 @@ Game Breakable(KEM K) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.EncapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        dk0 = kp0[1];
-        dk1 = kp1[1];
-        return [kp0[0], kp1[0]];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
+        return [ek0, ek1];
     }
 
     K.SharedSecret Decaps0(K.Ciphertext ct) {
@@ -57,11 +55,9 @@ Game Unbreakable(KEM K) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.EncapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        dk0 = kp0[1];
-        dk1 = kp1[1];
-        return [kp0[0], kp1[0]];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
+        return [ek0, ek1];
     }
 
     K.SharedSecret Decaps0(K.Ciphertext ct) {

--- a/applications/cfrg-hybrid-kems/games/KEM/Binding/LEAK_BIND_K_CT.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/Binding/LEAK_BIND_K_CT.game
@@ -25,11 +25,9 @@ Game Breakable(KEM K) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        dk0 = kp0[1];
-        dk1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
+        return [ek0, dk0, ek1, dk1];
     }
 
     Bool Challenge(K.Ciphertext ct0, K.Ciphertext ct1) {
@@ -44,11 +42,9 @@ Game Unbreakable(KEM K) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        dk0 = kp0[1];
-        dk1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
+        return [ek0, dk0, ek1, dk1];
     }
 
     Bool Challenge(K.Ciphertext ct0, K.Ciphertext ct1) {

--- a/applications/cfrg-hybrid-kems/games/KEM/Binding/LEAK_BIND_K_CT_ROM.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/Binding/LEAK_BIND_K_CT_ROM.game
@@ -18,11 +18,9 @@ Game Breakable(KEM K, Set D, Set R, Function<D, R> G_RO) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        dk0 = kp0[1];
-        dk1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
+        return [ek0, dk0, ek1, dk1];
     }
 
     Bool Challenge(K.Ciphertext ct0, K.Ciphertext ct1) {
@@ -41,11 +39,9 @@ Game Unbreakable(KEM K, Set D, Set R, Function<D, R> G_RO) {
     K.DecapsKey dk1;
 
     [K.EncapsKey, K.DecapsKey, K.EncapsKey, K.DecapsKey] Initialize() {
-        [K.EncapsKey, K.DecapsKey] kp0 = K.KeyGen();
-        [K.EncapsKey, K.DecapsKey] kp1 = K.KeyGen();
-        dk0 = kp0[1];
-        dk1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [K.EncapsKey, K.DecapsKey] [ek0, dk0] = K.KeyGen();
+        [K.EncapsKey, K.DecapsKey] [ek1, dk1] = K.KeyGen();
+        return [ek0, dk0, ek1, dk1];
     }
 
     Bool Challenge(K.Ciphertext ct0, K.Ciphertext ct1) {

--- a/applications/cfrg-hybrid-kems/games/KEM/Correctness.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/Correctness.game
@@ -28,9 +28,9 @@ Game FromDecaps(KEM K) {
 
 Game FromEncaps(KEM K) {
     [K.EncapsKey, K.Ciphertext, K.SharedSecret, K.SharedSecret] Compute() {
-        [K.EncapsKey, K.DecapsKey] keys = K.KeyGen();
-        [K.SharedSecret, K.Ciphertext] [ss, ct] = K.Encaps(keys[0]);
-        return [keys[0], ct, ss, ss];
+        [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
+        [K.SharedSecret, K.Ciphertext] [ss, ct] = K.Encaps(ek);
+        return [ek, ct, ss, ss];
     }
 }
 

--- a/applications/cfrg-hybrid-kems/games/KEM/INDCCA_ROM.game
+++ b/applications/cfrg-hybrid-kems/games/KEM/INDCCA_ROM.game
@@ -40,10 +40,9 @@ Game Random(KEM K, Set D, Set R, Function<D, R> H) {
 
     [K.EncapsKey, K.SharedSecret, K.Ciphertext] Initialize() {
         [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen();
-        [K.SharedSecret, K.Ciphertext] rsp = K.Encaps(ek);
+        [K.SharedSecret, K.Ciphertext] [ss_unused, ctStar] = K.Encaps(ek);
         K.SharedSecret ss <- K.SharedSecret;
-        ctStar = rsp[1];
-        return [ek, ss, rsp[1]];
+        return [ek, ss, ctStar];
     }
 
     K.SharedSecret? Decaps(K.Ciphertext c) {

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_Correctness.proof
@@ -90,8 +90,7 @@ Reduction R_KEM_PQ(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_expanded hybr
 Reduction R_NG(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_expanded hybrid)
     compose NGCorrectness(NG) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_INDCCA_PQ.proof
@@ -351,8 +351,7 @@ Reduction RD(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_expanded hyb
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -393,8 +392,7 @@ Reduction RE(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_expanded hyb
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -436,8 +434,7 @@ Game GameFreshSS(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_expanded
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_INDCCA_T.proof
@@ -174,8 +174,7 @@ Reduction R_Dist_Random(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_expanded
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<hybrid.Nss> ss <- BitString<hybrid.Nss>;
         ctStar = [ct_PQ, ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_expanded_LEAK_BIND_K_CT.proof
@@ -116,20 +116,18 @@ Reduction R_KDF(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, CG_expanded hybrid)
     NG.Element ek_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.KeyGen();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.KeyGen();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ_0] = KEM_PQ.KeyGen();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ_1] = KEM_PQ.KeyGen();
         BitString<NG.Nseed> seed_T_0 <- BitString<NG.Nseed>;
         BitString<NG.Nseed> seed_T_1 <- BitString<NG.Nseed>;
-        dk_PQ_0 = pq_kp_0[1];
-        dk_PQ_1 = pq_kp_1[1];
         dk_T_0 = NG.RandomScalar(seed_T_0);
         dk_T_1 = NG.RandomScalar(seed_T_1);
         ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);
         ek_T_1 = NG.Exp(NG.Generator(), dk_T_1);
-        hybrid.EncapsKey ek0 = [pq_kp_0[0], ek_T_0];
-        hybrid.DecapsKey dk0 = [pq_kp_0[1], dk_T_0, ek_T_0];
-        hybrid.EncapsKey ek1 = [pq_kp_1[0], ek_T_1];
-        hybrid.DecapsKey dk1 = [pq_kp_1[1], dk_T_1, ek_T_1];
+        hybrid.EncapsKey ek0 = [ek_PQ, ek_T_0];
+        hybrid.DecapsKey dk0 = [dk_PQ_0, dk_T_0, ek_T_0];
+        hybrid.EncapsKey ek1 = [ek_PQ2, ek_T_1];
+        hybrid.DecapsKey dk1 = [dk_PQ_1, dk_T_1, ek_T_1];
         return [ek0, dk0, ek1, dk1];
     }
 

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_Correctness.proof
@@ -174,8 +174,7 @@ Reduction R_KEM_PQ(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedba
 Reduction R_NG(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased hybrid)
     compose NGCorrectness(NG) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
@@ -196,11 +195,10 @@ Reduction R_NG(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased 
 Reduction R_KG_PQ_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased hybrid)
     compose KeyGenEquiv(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = challenger.Generate();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -218,8 +216,7 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
         BitString<G.lambda + G.stretch> seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_INDCCA_PQ.proof
@@ -115,8 +115,7 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
@@ -134,11 +133,11 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_unused, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         NG.Element c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ, c1);
         BitString<NG.Nss> dec_ss_T = NG.ElementToSharedSecret(NG.Exp(c2, dk_T));
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || NG.Encode(c2) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
         return H.evaluate(kdf_in);
@@ -154,12 +153,10 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -172,11 +169,11 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbas
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_unused, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         NG.Element c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ, c1);
         BitString<NG.Nss> dec_ss_T = NG.ElementToSharedSecret(NG.Exp(c2, dk_T));
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || NG.Encode(c2) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
         return H.evaluate(kdf_in);
@@ -233,8 +230,7 @@ Reduction R_KG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbase
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -519,8 +515,7 @@ Reduction RD(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased hy
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -561,8 +556,7 @@ Reduction RE(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbased hy
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -605,8 +599,7 @@ Game GameFreshSS(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, CG_seedbase
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_INDCCA_T.proof
@@ -163,8 +163,7 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hybr
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_unused] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
@@ -183,11 +182,11 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hybr
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_unused, dk_PQ2] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         NG.Element c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ2, c1);
         BitString<NG.Nss> dec_ss_T = NG.ElementToSharedSecret(NG.Exp(c2, dk_T));
         BitString<hybrid.Nin> kdf_in =
             KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || NG.Encode(c2) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
@@ -208,12 +207,10 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hybr
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_unused] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -226,11 +223,11 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hybr
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_unused, dk_PQ2] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         NG.Element c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ2, c1);
         BitString<NG.Nss> dec_ss_T = NG.ElementToSharedSecret(NG.Exp(c2, dk_T));
         BitString<hybrid.Nin> kdf_in =
             KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || dec_ss_T || NG.Encode(c2) || NG.Encode(NG.Exp(NG.Generator(), dk_T)) || L.get();
@@ -298,8 +295,7 @@ Reduction R_KG_R(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbased hybri
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -376,8 +372,7 @@ Reduction R_Dist_Random(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, CG_seedbase
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<hybrid.Nss> ss <- BitString<hybrid.Nss>;
         ctStar = [ct_PQ, ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CG/CG_seedbased_LEAK_BIND_K_CT.proof
@@ -182,15 +182,13 @@ Reduction R_LazyRO_L(KEM KEM_PQ, NominalGroup NG, Int lambda,
         [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         BitString<KEM_PQ.Nseed + NG.Nseed> y_0 = challenger.Hash(seed_0);
         BitString<KEM_PQ.Nseed + NG.Nseed> y_1 = challenger.Hash(seed_1);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(y_1[0 : KEM_PQ.Nseed]);
-        dk_PQ_0 = pq_kp_0[1];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ_0] = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ_1] = KEM_PQ.DeriveKeyPair(y_1[0 : KEM_PQ.Nseed]);
         dk_T_0 = NG.RandomScalar(y_0[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed]);
         dk_T_1 = NG.RandomScalar(y_1[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed]);
         NG.Element ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);
         NG.Element ek_T_1 = NG.Exp(NG.Generator(), dk_T_1);
-        return [[pq_kp_0[0], ek_T_0], seed_0, [pq_kp_1[0], ek_T_1], seed_1];
+        return [[ek_PQ, ek_T_0], seed_0, [ek_PQ2, ek_T_1], seed_1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {
@@ -223,15 +221,13 @@ Reduction R_LazyRO_R(KEM KEM_PQ, NominalGroup NG, Int lambda,
         [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
         BitString<KEM_PQ.Nseed + NG.Nseed> y_0 = challenger.Hash(seed_0);
         BitString<KEM_PQ.Nseed + NG.Nseed> y_1 = challenger.Hash(seed_1);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(y_1[0 : KEM_PQ.Nseed]);
-        dk_PQ_0 = pq_kp_0[1];
-        dk_PQ_1 = pq_kp_1[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ_0] = KEM_PQ.DeriveKeyPair(y_0[0 : KEM_PQ.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ_1] = KEM_PQ.DeriveKeyPair(y_1[0 : KEM_PQ.Nseed]);
         dk_T_0 = NG.RandomScalar(y_0[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed]);
         dk_T_1 = NG.RandomScalar(y_1[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed]);
         NG.Element ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);
         NG.Element ek_T_1 = NG.Exp(NG.Generator(), dk_T_1);
-        return [[pq_kp_0[0], ek_T_0], seed_0, [pq_kp_1[0], ek_T_1], seed_1];
+        return [[ek_PQ, ek_T_0], seed_0, [ek_PQ2, ek_T_1], seed_1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_Correctness.proof
@@ -88,8 +88,7 @@ Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
     compose KEMCorrectness(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
         [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] [ek_T, ct_T, ss_T_e, ss_T_d] = challenger.Compute();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_INDCCA_PQ.proof
@@ -144,8 +144,7 @@ Reduction R_Correct_Ideal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expan
         KEM_PQ.EncapsKey ek_PQ = corr[0];
         KEM_PQ.Ciphertext ct_PQ = corr[2];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -219,8 +218,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expande
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -291,8 +289,7 @@ Reduction RC(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
         [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -330,8 +327,7 @@ Reduction RD(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_T.EncodeSharedSecret(ss_T), rest);
@@ -367,10 +363,8 @@ Reduction RE(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -407,10 +401,8 @@ Game GameFreshSS(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybri
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_INDCCA_T.proof
@@ -161,8 +161,7 @@ Reduction R_Correct_T_Ideal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_exp
         KEM_T.EncapsKey ek_T = corr[0];
         KEM_T.Ciphertext ct_T = corr[2];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -271,8 +270,7 @@ Reduction R_KEM_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -310,8 +308,7 @@ Game G_RandSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || ss_T_star || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
@@ -352,8 +349,7 @@ Reduction R_C2PRI_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ_star) || ss_T_star || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
@@ -396,8 +392,7 @@ Reduction R_C2PRI_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ_star, kem_ct_T];
@@ -441,8 +436,7 @@ Game G_Abort(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid) {
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ_star) || ss_T_star || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
@@ -487,8 +481,7 @@ Reduction R_PRF_Fwd(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_PQ.EncodeSharedSecret(ss_PQ_star), rest);
         ctStar = [ct_PQ, kem_ct_T];
@@ -529,8 +522,7 @@ Reduction R_PRF_Rev(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -573,8 +565,7 @@ Game G_AllRand(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -616,8 +607,7 @@ Game G_Unwound(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hybrid)
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
@@ -658,10 +648,8 @@ Game G_Consolidated(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
@@ -698,8 +686,7 @@ Game G_StoredSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_expanded hy
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_LEAK_BIND_K_CT.proof
@@ -102,16 +102,12 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0, ek_PQ_1, dk_PQ_1] = challenger.Initialize();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.KeyGen();
-        dk_T_0 = t_kp_0[1];
-        ek_T_0 = t_kp_0[0];
-        dk_T_1 = t_kp_1[1];
-        ek_T_1 = t_kp_1[0];
-        hybrid.EncapsKey ek0 = [ek_PQ_0, t_kp_0[0]];
-        hybrid.DecapsKey dk0 = [dk_PQ_0, t_kp_0[1], t_kp_0[0]];
-        hybrid.EncapsKey ek1 = [ek_PQ_1, t_kp_1[0]];
-        hybrid.DecapsKey dk1 = [dk_PQ_1, t_kp_1[1], t_kp_1[0]];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.KeyGen();
+        hybrid.EncapsKey ek0 = [ek_PQ_0, ek_T_0];
+        hybrid.DecapsKey dk0 = [dk_PQ_0, dk_T_0, ek_T_0];
+        hybrid.EncapsKey ek1 = [ek_PQ_1, ek_T_1];
+        hybrid.DecapsKey dk1 = [dk_PQ_1, dk_T_1, ek_T_1];
         return [ek0, dk0, ek1, dk1];
     }
 
@@ -142,20 +138,14 @@ Reduction R_KDF(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
     KEM_T.EncapsKey ek_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.KeyGen();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.KeyGen();
-        dk_PQ_0 = pq_kp_0[1];
-        dk_T_0 = t_kp_0[1];
-        ek_T_0 = t_kp_0[0];
-        dk_PQ_1 = pq_kp_1[1];
-        dk_T_1 = t_kp_1[1];
-        ek_T_1 = t_kp_1[0];
-        hybrid.EncapsKey ek0 = [pq_kp_0[0], t_kp_0[0]];
-        hybrid.DecapsKey dk0 = [pq_kp_0[1], t_kp_0[1], t_kp_0[0]];
-        hybrid.EncapsKey ek1 = [pq_kp_1[0], t_kp_1[0]];
-        hybrid.DecapsKey dk1 = [pq_kp_1[1], t_kp_1[1], t_kp_1[0]];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ_0] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.KeyGen();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ_1] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.KeyGen();
+        hybrid.EncapsKey ek0 = [ek_PQ, ek_T_0];
+        hybrid.DecapsKey dk0 = [dk_PQ_0, dk_T_0, ek_T_0];
+        hybrid.EncapsKey ek1 = [ek_PQ2, ek_T_1];
+        hybrid.DecapsKey dk1 = [dk_PQ_1, dk_T_1, ek_T_1];
         return [ek0, dk0, ek1, dk1];
     }
 

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_expanded_LEAK_BIND_K_PK.proof
@@ -104,16 +104,12 @@ Reduction R_PQ_Bind(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0, ek_PQ_1, dk_PQ_1] = challenger.Initialize();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.KeyGen();
-        dk_T_0 = t_kp_0[1];
-        ek_T_0 = t_kp_0[0];
-        dk_T_1 = t_kp_1[1];
-        ek_T_1 = t_kp_1[0];
-        hybrid.EncapsKey ek0 = [ek_PQ_0, t_kp_0[0]];
-        hybrid.DecapsKey dk0 = [dk_PQ_0, t_kp_0[1], t_kp_0[0]];
-        hybrid.EncapsKey ek1 = [ek_PQ_1, t_kp_1[0]];
-        hybrid.DecapsKey dk1 = [dk_PQ_1, t_kp_1[1], t_kp_1[0]];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.KeyGen();
+        hybrid.EncapsKey ek0 = [ek_PQ_0, ek_T_0];
+        hybrid.DecapsKey dk0 = [dk_PQ_0, dk_T_0, ek_T_0];
+        hybrid.EncapsKey ek1 = [ek_PQ_1, ek_T_1];
+        hybrid.DecapsKey dk1 = [dk_PQ_1, dk_T_1, ek_T_1];
         return [ek0, dk0, ek1, dk1];
     }
 
@@ -148,22 +144,14 @@ Reduction R_KDF(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, CK_expanded hybrid)
     KEM_T.EncapsKey ek_T_1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.KeyGen();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.KeyGen();
-        ek_PQ_0 = pq_kp_0[0];
-        dk_PQ_0 = pq_kp_0[1];
-        ek_PQ_1 = pq_kp_1[0];
-        dk_PQ_1 = pq_kp_1[1];
-        dk_T_0 = t_kp_0[1];
-        ek_T_0 = t_kp_0[0];
-        dk_T_1 = t_kp_1[1];
-        ek_T_1 = t_kp_1[0];
-        hybrid.EncapsKey ek0 = [pq_kp_0[0], t_kp_0[0]];
-        hybrid.DecapsKey dk0 = [pq_kp_0[1], t_kp_0[1], t_kp_0[0]];
-        hybrid.EncapsKey ek1 = [pq_kp_1[0], t_kp_1[0]];
-        hybrid.DecapsKey dk1 = [pq_kp_1[1], t_kp_1[1], t_kp_1[0]];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_0, dk_PQ_0] = KEM_PQ.KeyGen();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ_1, dk_PQ_1] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_0, dk_T_0] = KEM_T.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T_1, dk_T_1] = KEM_T.KeyGen();
+        hybrid.EncapsKey ek0 = [ek_PQ_0, ek_T_0];
+        hybrid.DecapsKey dk0 = [dk_PQ_0, dk_T_0, ek_T_0];
+        hybrid.EncapsKey ek1 = [ek_PQ_1, ek_T_1];
+        hybrid.DecapsKey dk1 = [dk_PQ_1, dk_T_1, ek_T_1];
         return [ek0, dk0, ek1, dk1];
     }
 

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_Correctness.proof
@@ -178,8 +178,7 @@ Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
     compose KEMCorrectness(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
         [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] [ek_T, ct_T, ss_T_e, ss_T_d] = challenger.Compute();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -192,10 +191,8 @@ Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
 Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
     compose KeyGenEquiv(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = challenger.Generate();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_T.EncapsKey ek_T = t_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = challenger.Generate();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -207,11 +204,9 @@ Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hy
 Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
     compose KeyGenEquiv(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = challenger.Generate();
         BitString<KEM_T.Nseed> seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_T.EncapsKey ek_T = t_keys[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -226,10 +221,8 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         BitString<G.lambda + G.stretch> seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_T.EncapsKey ek_T = t_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_CT.proof
@@ -186,11 +186,11 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [hybrid.EncapsKey, hybrid.EncapsKey] Initialize() {
         pq_keys_0 = challenger.Generate();
         seed_T_0 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T_0);
         pq_keys_1 = challenger.Generate();
         seed_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(seed_T_1);
-        return [[pq_keys_0[0], t_kp_0[0]], [pq_keys_1[0], t_kp_1[0]]];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_unused] = KEM_T.DeriveKeyPair(seed_T_1);
+        return [[pq_keys_0[0], ek_T], [pq_keys_1[0], ek_T2]];
     }
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {
@@ -214,15 +214,15 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {
         KEM_T.Ciphertext ct_T_0 = ct0[1];
         KEM_T.Ciphertext ct_T_1 = ct1[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys_0 = KEM_T.DeriveKeyPair(seed_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys_1 = KEM_T.DeriveKeyPair(seed_T_1);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_T2] = KEM_T.DeriveKeyPair(seed_T_1);
         KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(pq_keys_0[1], ct0[0]);
-        KEM_T.SharedSecret ss_T_0 = KEM_T.Decaps(t_keys_0[1], ct_T_0);
+        KEM_T.SharedSecret ss_T_0 = KEM_T.Decaps(dk_T, ct_T_0);
         BitString<L.Nlabel> lbl = L.get();
-        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || KEM_T.EncodeSharedSecret(ss_T_0) || KEM_T.EncodeCiphertext(ct_T_0) || KEM_T.EncodeEncapsKey(t_keys_0[0]) || lbl;
+        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || KEM_T.EncodeSharedSecret(ss_T_0) || KEM_T.EncodeCiphertext(ct_T_0) || KEM_T.EncodeEncapsKey(ek_T) || lbl;
         KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(pq_keys_1[1], ct1[0]);
-        KEM_T.SharedSecret ss_T_1 = KEM_T.Decaps(t_keys_1[1], ct_T_1);
-        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || KEM_T.EncodeSharedSecret(ss_T_1) || KEM_T.EncodeCiphertext(ct_T_1) || KEM_T.EncodeEncapsKey(t_keys_1[0]) || lbl;
+        KEM_T.SharedSecret ss_T_1 = KEM_T.Decaps(dk_T2, ct_T_1);
+        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || KEM_T.EncodeSharedSecret(ss_T_1) || KEM_T.EncodeCiphertext(ct_T_1) || KEM_T.EncodeEncapsKey(ek_T2) || lbl;
         return H.evaluate(kdf_in_0) == H.evaluate(kdf_in_1) && ct0 != ct1;
     }
 }
@@ -436,9 +436,9 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         pq_keys_1 = challenger.Generate();
         seed_T_0 <- BitString<KEM_T.Nseed>;
         seed_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(seed_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(seed_T_1);
-        return [[pq_keys_0[0], t_kp_0[0]], [pq_keys_1[0], t_kp_1[0]]];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_unused] = KEM_T.DeriveKeyPair(seed_T_1);
+        return [[pq_keys_0[0], ek_T], [pq_keys_1[0], ek_T2]];
     }
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_HON_BIND_K_PK.proof
@@ -185,11 +185,11 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [hybrid.EncapsKey, hybrid.EncapsKey] Initialize() {
         pq_keys_0 = challenger.Generate();
         seed_T_0 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T_0);
         pq_keys_1 = challenger.Generate();
         seed_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(seed_T_1);
-        return [[pq_keys_0[0], t_kp_0[0]], [pq_keys_1[0], t_kp_1[0]]];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_unused] = KEM_T.DeriveKeyPair(seed_T_1);
+        return [[pq_keys_0[0], ek_T], [pq_keys_1[0], ek_T2]];
     }
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {
@@ -213,17 +213,17 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {
         KEM_T.Ciphertext ct_T_0 = ct0[1];
         KEM_T.Ciphertext ct_T_1 = ct1[1];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys_0 = KEM_T.DeriveKeyPair(seed_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys_1 = KEM_T.DeriveKeyPair(seed_T_1);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_T2] = KEM_T.DeriveKeyPair(seed_T_1);
         KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(pq_keys_0[1], ct0[0]);
-        KEM_T.SharedSecret ss_T_0 = KEM_T.Decaps(t_keys_0[1], ct_T_0);
+        KEM_T.SharedSecret ss_T_0 = KEM_T.Decaps(dk_T, ct_T_0);
         BitString<L.Nlabel> lbl = L.get();
-        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || KEM_T.EncodeSharedSecret(ss_T_0) || KEM_T.EncodeCiphertext(ct_T_0) || KEM_T.EncodeEncapsKey(t_keys_0[0]) || lbl;
+        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || KEM_T.EncodeSharedSecret(ss_T_0) || KEM_T.EncodeCiphertext(ct_T_0) || KEM_T.EncodeEncapsKey(ek_T) || lbl;
         KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(pq_keys_1[1], ct1[0]);
-        KEM_T.SharedSecret ss_T_1 = KEM_T.Decaps(t_keys_1[1], ct_T_1);
-        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || KEM_T.EncodeSharedSecret(ss_T_1) || KEM_T.EncodeCiphertext(ct_T_1) || KEM_T.EncodeEncapsKey(t_keys_1[0]) || lbl;
-        hybrid.EncapsKey ek0 = [pq_keys_0[0], t_keys_0[0]];
-        hybrid.EncapsKey ek1 = [pq_keys_1[0], t_keys_1[0]];
+        KEM_T.SharedSecret ss_T_1 = KEM_T.Decaps(dk_T2, ct_T_1);
+        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || KEM_T.EncodeSharedSecret(ss_T_1) || KEM_T.EncodeCiphertext(ct_T_1) || KEM_T.EncodeEncapsKey(ek_T2) || lbl;
+        hybrid.EncapsKey ek0 = [pq_keys_0[0], ek_T];
+        hybrid.EncapsKey ek1 = [pq_keys_1[0], ek_T2];
         return H.evaluate(kdf_in_0) == H.evaluate(kdf_in_1) && ek0 != ek1;
     }
 }
@@ -436,9 +436,9 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         pq_keys_1 = challenger.Generate();
         seed_T_0 <- BitString<KEM_T.Nseed>;
         seed_T_1 <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(seed_T_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(seed_T_1);
-        return [[pq_keys_0[0], t_kp_0[0]], [pq_keys_1[0], t_kp_1[0]]];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_unused] = KEM_T.DeriveKeyPair(seed_T_1);
+        return [[pq_keys_0[0], ek_T], [pq_keys_1[0], ek_T2]];
     }
 
     hybrid.SharedSecret Decaps0(hybrid.Ciphertext ct) {

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_PQ.proof
@@ -131,10 +131,8 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -147,11 +145,11 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_unused, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ, c1);
         KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
@@ -167,14 +165,10 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -184,11 +178,11 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_unused, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ, c1);
         KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
@@ -207,8 +201,7 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
         pq_keys = challenger.Generate();
         seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
@@ -239,13 +232,10 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
         pq_keys = challenger.Generate();
         seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -307,10 +297,8 @@ Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hy
         t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -378,8 +366,7 @@ Reduction R_Correct_Ideal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedb
         KEM_PQ.EncapsKey ek_PQ = corr[0];
         KEM_PQ.Ciphertext ct_PQ = corr[2];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -454,8 +441,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbas
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -526,8 +512,7 @@ Reduction RC(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
         [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -566,8 +551,7 @@ Reduction RD(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_T.EncodeSharedSecret(ss_T), rest);
@@ -603,10 +587,8 @@ Reduction RE(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -644,10 +626,8 @@ Game GameFreshSS(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybr
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_INDCCA_T.proof
@@ -160,10 +160,8 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_unused] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_T.EncodeCiphertext(ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -176,11 +174,11 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_unused, dk_PQ2] = KEM_PQ.DeriveKeyPair(seed_PQ);
         [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ2, c1);
         KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
@@ -196,14 +194,10 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_unused] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -213,11 +207,11 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hyb
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_unused, dk_PQ2] = KEM_PQ.DeriveKeyPair(seed_PQ);
         [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek, dk] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ2, c1);
         KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk, c2);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_T.EncodeCiphertext(c2) || KEM_T.EncodeEncapsKey(ek) || L.get();
         return H.evaluate(kdf_in);
@@ -233,8 +227,7 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
         pq_keys = challenger.Generate();
         seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
@@ -265,13 +258,10 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
         pq_keys = challenger.Generate();
         seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -330,10 +320,8 @@ Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hy
         t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -405,8 +393,7 @@ Reduction R_Correct_T_Ideal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_see
         KEM_T.EncapsKey ek_T = corr[0];
         KEM_T.Ciphertext ct_T = corr[2];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -521,8 +508,7 @@ Reduction R_KEM_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -561,8 +547,7 @@ Game G_RandSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybri
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || ss_T_star || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
@@ -611,8 +596,7 @@ Reduction R_C2PRI_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ_star) || ss_T_star || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
@@ -655,8 +639,7 @@ Reduction R_C2PRI_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey, KEM_PQ.Ciphertext, KEM_PQ.SharedSecret] [ek_PQ, dk_PQ, ct_PQ_star, ss_PQ_star] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ_star, kem_ct_T];
@@ -703,8 +686,7 @@ Game G_Abort(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid) 
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ_star) || ss_T_star || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
@@ -758,8 +740,7 @@ Reduction R_PRF_Fwd(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_T.EncodeCiphertext(kem_ct_T) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_PQ.EncodeSharedSecret(ss_PQ_star), rest);
         ctStar = [ct_PQ, kem_ct_T];
@@ -800,8 +781,7 @@ Reduction R_PRF_Rev(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -846,8 +826,7 @@ Game G_AllRand(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -892,8 +871,7 @@ Game G_Unwound(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased hybrid
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ_star, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
@@ -936,10 +914,8 @@ Game G_Consolidated(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
@@ -978,8 +954,7 @@ Game G_StoredSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, CK_seedbased h
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/CK/CK_seedbased_LEAK_BIND_K_CT.proof
@@ -184,13 +184,11 @@ Reduction R_LazyRO_L(KEM KEM_PQ, KEM KEM_T, Int lambda,
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
         [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ_0] = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
         [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ_1] = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
         [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
-        dk_PQ_0 = pq_kp_0[1];
-        dk_PQ_1 = pq_kp_1[1];
-        return [[pq_kp_0[0], ek_T_0], seed_0, [pq_kp_1[0], ek_T_1], seed_1];
+        return [[ek_PQ, ek_T_0], seed_0, [ek_PQ2, ek_T_1], seed_1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {
@@ -223,13 +221,11 @@ Reduction R_LazyRO_R(KEM KEM_PQ, KEM KEM_T, Int lambda,
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
         [BitString<lambda>, BitString<lambda>] [seed_0, seed_1] = challenger.Initialize();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ_0] = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_0)[0 : KEM_PQ.Nseed]);
         [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_0, dk_T_0] = KEM_T.DeriveKeyPair(challenger.Hash(seed_0)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ_1] = KEM_PQ.DeriveKeyPair(challenger.Hash(seed_1)[0 : KEM_PQ.Nseed]);
         [KEM_T.EncapsKey,  KEM_T.DecapsKey]  [ek_T_1, dk_T_1] = KEM_T.DeriveKeyPair(challenger.Hash(seed_1)[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed]);
-        dk_PQ_0 = pq_kp_0[1];
-        dk_PQ_1 = pq_kp_1[1];
-        return [[pq_kp_0[0], ek_T_0], seed_0, [pq_kp_1[0], ek_T_1], seed_1];
+        return [[ek_PQ, ek_T_0], seed_0, [ek_PQ2, ek_T_1], seed_1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_Correctness.proof
@@ -94,8 +94,7 @@ Reduction R_KEM_PQ(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, UG_expanded hybr
 Reduction R_NG(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, UG_expanded hybrid)
     compose NGCorrectness(NG) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_INDCCA_PQ.proof
@@ -359,8 +359,7 @@ Reduction RD(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_expanded hyb
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -401,8 +400,7 @@ Reduction RE(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_expanded hyb
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -447,8 +445,7 @@ Game GameFreshSS(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_expanded
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_INDCCA_T.proof
@@ -166,8 +166,7 @@ Reduction R_Dist_Random(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_expanded
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<hybrid.Nss> ss <- BitString<hybrid.Nss>;
         ctStar = [ct_PQ, ct_T];
@@ -231,8 +230,7 @@ Reduction R_Wrap_NoAbort(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G,
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Scalar sk_E <- NG.Scalar;
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         [KEM_PQ.Ciphertext, NG.Element] ctStar = [ct_PQ, ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_LEAK_BIND_K_CT.proof
@@ -66,11 +66,9 @@ Reduction R(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, UG_expanded hybrid)
     hybrid.DecapsKey dk1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp0 = hybrid.KeyGen();
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp1 = hybrid.KeyGen();
-        dk0 = kp0[1];
-        dk1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek0, dk0] = hybrid.KeyGen();
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek1, dk1] = hybrid.KeyGen();
+        return [ek0, dk0, ek1, dk1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_expanded_LEAK_BIND_K_PK.proof
@@ -68,13 +68,9 @@ Reduction R(KEM KEM_PQ, NominalGroup NG, KDF H, Label L, UG_expanded hybrid)
     hybrid.EncapsKey ek1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp0 = hybrid.KeyGen();
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp1 = hybrid.KeyGen();
-        ek0 = kp0[0];
-        dk0 = kp0[1];
-        ek1 = kp1[0];
-        dk1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek0, dk0] = hybrid.KeyGen();
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek1, dk1] = hybrid.KeyGen();
+        return [ek0, dk0, ek1, dk1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_Correctness.proof
@@ -178,8 +178,7 @@ Reduction R_KEM_PQ(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedba
 Reduction R_NG(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hybrid)
     compose NGCorrectness(NG) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
@@ -200,11 +199,10 @@ Reduction R_NG(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased 
 Reduction R_KG_PQ_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hybrid)
     compose KeyGenEquiv(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = challenger.Generate();
         BitString<NG.Nseed> seed_T <- BitString<NG.Nseed>;
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
@@ -222,8 +220,7 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
         BitString<G.lambda + G.stretch> seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_PQ.proof
@@ -119,8 +119,7 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
@@ -158,12 +157,10 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbas
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -238,8 +235,7 @@ Reduction R_KG_R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbase
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -526,8 +522,7 @@ Reduction RD(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hy
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -568,8 +563,7 @@ Reduction RE(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hy
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -612,8 +606,7 @@ Game GameFreshSS(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbase
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_INDCCA_T.proof
@@ -143,8 +143,7 @@ Reduction R_PRG_L(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased hybr
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_unused] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
@@ -188,12 +187,10 @@ Reduction R_PRG_R(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased hybr
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_unused] = KEM_PQ.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -278,8 +275,7 @@ Reduction R_KG_R(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbased hybri
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<NG.Nseed> seed_E <- BitString<NG.Nseed>;
         NG.Scalar sk_E = NG.RandomScalar(seed_E);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
@@ -356,8 +352,7 @@ Reduction R_Dist_Random(KEM KEM_PQ, NominalGroup NG, PRG G, Label L, UG_seedbase
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         BitString<hybrid.Nss> ss <- BitString<hybrid.Nss>;
         ctStar = [ct_PQ, ct_T];
@@ -421,8 +416,7 @@ Reduction R_Wrap_NoAbort(KEM KEM_PQ, NominalGroup NG, HashInputPacking P, PRG G,
         [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         NG.Scalar dk_T <- NG.Scalar;
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         NG.Scalar sk_E <- NG.Scalar;
         NG.Element ct_T = NG.Exp(NG.Generator(), sk_E);
         [KEM_PQ.Ciphertext, NG.Element] ctStar = [ct_PQ, ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_LEAK_BIND_K_CT.proof
@@ -63,11 +63,9 @@ Reduction R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hyb
     BitString<G.lambda> seed1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp0 = hybrid.KeyGen();
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp1 = hybrid.KeyGen();
-        seed0 = kp0[1];
-        seed1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek0, seed0] = hybrid.KeyGen();
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek1, seed1] = hybrid.KeyGen();
+        return [ek0, seed0, ek1, seed1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {
@@ -76,26 +74,26 @@ Reduction R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hyb
         BitString<G.lambda + G.stretch> seed_full_0 = G.evaluate(seed0);
         BitString<KEM_PQ.Nseed> seed_PQ_0 = seed_full_0[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T_0 = seed_full_0[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(seed_PQ_0);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ_0);
         NG.Scalar dk_T_0 = NG.RandomScalar(seed_T_0);
         NG.Element ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);
         KEM_PQ.Ciphertext ct_PQ_0 = ct0[0];
         NG.Element ct_T_0 = ct0[1];
-        KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(pq_kp_0[1], ct_PQ_0);
+        KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(dk_PQ, ct_PQ_0);
         BitString<NG.Nss> ss_T_0 = NG.ElementToSharedSecret(NG.Exp(ct_T_0, dk_T_0));
-        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || ss_T_0 || KEM_PQ.EncodeCiphertext(ct_PQ_0) || NG.Encode(ct_T_0) || KEM_PQ.EncodeEncapsKey(pq_kp_0[0]) || NG.Encode(ek_T_0) || L.get();
+        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || ss_T_0 || KEM_PQ.EncodeCiphertext(ct_PQ_0) || NG.Encode(ct_T_0) || KEM_PQ.EncodeEncapsKey(ek_PQ) || NG.Encode(ek_T_0) || L.get();
 
         BitString<G.lambda + G.stretch> seed_full_1 = G.evaluate(seed1);
         BitString<KEM_PQ.Nseed> seed_PQ_1 = seed_full_1[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T_1 = seed_full_1[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(seed_PQ_1);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ2] = KEM_PQ.DeriveKeyPair(seed_PQ_1);
         NG.Scalar dk_T_1 = NG.RandomScalar(seed_T_1);
         NG.Element ek_T_1 = NG.Exp(NG.Generator(), dk_T_1);
         KEM_PQ.Ciphertext ct_PQ_1 = ct1[0];
         NG.Element ct_T_1 = ct1[1];
-        KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(pq_kp_1[1], ct_PQ_1);
+        KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(dk_PQ2, ct_PQ_1);
         BitString<NG.Nss> ss_T_1 = NG.ElementToSharedSecret(NG.Exp(ct_T_1, dk_T_1));
-        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || ss_T_1 || KEM_PQ.EncodeCiphertext(ct_PQ_1) || NG.Encode(ct_T_1) || KEM_PQ.EncodeEncapsKey(pq_kp_1[0]) || NG.Encode(ek_T_1) || L.get();
+        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || ss_T_1 || KEM_PQ.EncodeCiphertext(ct_PQ_1) || NG.Encode(ct_T_1) || KEM_PQ.EncodeEncapsKey(ek_PQ2) || NG.Encode(ek_T_1) || L.get();
 
         if (ct0 == ct1) {
             return false;

--- a/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UG/UG_seedbased_LEAK_BIND_K_PK.proof
@@ -65,39 +65,35 @@ Reduction R(KEM KEM_PQ, NominalGroup NG, PRG G, KDF H, Label L, UG_seedbased hyb
     hybrid.EncapsKey ek1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp0 = hybrid.KeyGen();
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp1 = hybrid.KeyGen();
-        ek0 = kp0[0];
-        seed0 = kp0[1];
-        ek1 = kp1[0];
-        seed1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek0, seed0] = hybrid.KeyGen();
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek1, seed1] = hybrid.KeyGen();
+        return [ek0, seed0, ek1, seed1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {
         BitString<G.lambda + G.stretch> seed_full_0 = G.evaluate(seed0);
         BitString<KEM_PQ.Nseed> seed_PQ_0 = seed_full_0[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T_0 = seed_full_0[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(seed_PQ_0);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ_0);
         NG.Scalar dk_T_0 = NG.RandomScalar(seed_T_0);
         NG.Element ek_T_0 = NG.Exp(NG.Generator(), dk_T_0);
         KEM_PQ.Ciphertext ct_PQ_0 = ct0[0];
         NG.Element ct_T_0 = ct0[1];
-        KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(pq_kp_0[1], ct_PQ_0);
+        KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(dk_PQ, ct_PQ_0);
         BitString<NG.Nss> ss_T_0 = NG.ElementToSharedSecret(NG.Exp(ct_T_0, dk_T_0));
-        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || ss_T_0 || KEM_PQ.EncodeCiphertext(ct_PQ_0) || NG.Encode(ct_T_0) || KEM_PQ.EncodeEncapsKey(pq_kp_0[0]) || NG.Encode(ek_T_0) || L.get();
+        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || ss_T_0 || KEM_PQ.EncodeCiphertext(ct_PQ_0) || NG.Encode(ct_T_0) || KEM_PQ.EncodeEncapsKey(ek_PQ) || NG.Encode(ek_T_0) || L.get();
 
         BitString<G.lambda + G.stretch> seed_full_1 = G.evaluate(seed1);
         BitString<KEM_PQ.Nseed> seed_PQ_1 = seed_full_1[0 : KEM_PQ.Nseed];
         BitString<NG.Nseed> seed_T_1 = seed_full_1[KEM_PQ.Nseed : KEM_PQ.Nseed + NG.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(seed_PQ_1);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ2] = KEM_PQ.DeriveKeyPair(seed_PQ_1);
         NG.Scalar dk_T_1 = NG.RandomScalar(seed_T_1);
         NG.Element ek_T_1 = NG.Exp(NG.Generator(), dk_T_1);
         KEM_PQ.Ciphertext ct_PQ_1 = ct1[0];
         NG.Element ct_T_1 = ct1[1];
-        KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(pq_kp_1[1], ct_PQ_1);
+        KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(dk_PQ2, ct_PQ_1);
         BitString<NG.Nss> ss_T_1 = NG.ElementToSharedSecret(NG.Exp(ct_T_1, dk_T_1));
-        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || ss_T_1 || KEM_PQ.EncodeCiphertext(ct_PQ_1) || NG.Encode(ct_T_1) || KEM_PQ.EncodeEncapsKey(pq_kp_1[0]) || NG.Encode(ek_T_1) || L.get();
+        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || ss_T_1 || KEM_PQ.EncodeCiphertext(ct_PQ_1) || NG.Encode(ct_T_1) || KEM_PQ.EncodeEncapsKey(ek_PQ2) || NG.Encode(ek_T_1) || L.get();
 
         if (ek0 == ek1) {
             return false;

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_Correctness.proof
@@ -83,8 +83,7 @@ Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, UK_expanded hybrid)
     compose KEMCorrectness(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
         [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] [ek_T, ct_T, ss_T_e, ss_T_d] = challenger.Compute();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_INDCCA_PQ.proof
@@ -136,8 +136,7 @@ Reduction R_Correct_Ideal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expan
         KEM_PQ.EncapsKey ek_PQ = corr[0];
         KEM_PQ.Ciphertext ct_PQ = corr[2];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -211,8 +210,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expande
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -283,8 +281,7 @@ Reduction RC(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid)
         [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -322,8 +319,7 @@ Reduction RD(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_PQ.EncodeCiphertext(kem_ct) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_T.EncodeSharedSecret(ss_T), rest);
@@ -359,10 +355,8 @@ Reduction RE(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -399,10 +393,8 @@ Game GameFreshSS(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybri
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_INDCCA_T.proof
@@ -144,8 +144,7 @@ Reduction R_Correct_T_Ideal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_exp
         KEM_T.EncapsKey ek_T = corr[0];
         KEM_T.Ciphertext ct_T = corr[2];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -254,8 +253,7 @@ Reduction R_KEM_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hy
         [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -293,8 +291,7 @@ Game G_RandSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || ss_T_star || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
@@ -334,8 +331,7 @@ Reduction R_PRF_Fwd(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hy
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_PQ.EncodeSharedSecret(ss_PQ), rest);
         ctStar = [ct_PQ, kem_ct_T];
@@ -370,10 +366,8 @@ Reduction R_PRF_Rev(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hy
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -410,10 +404,8 @@ Game G_AllRand(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -449,10 +441,8 @@ Game G_RandSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hybr
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
@@ -489,8 +479,7 @@ Game G_StoredSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_expanded hy
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_LEAK_BIND_K_CT.proof
@@ -63,11 +63,9 @@ Reduction R(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, UK_expanded hybrid)
     hybrid.DecapsKey dk1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp0 = hybrid.KeyGen();
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp1 = hybrid.KeyGen();
-        dk0 = kp0[1];
-        dk1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek0, dk0] = hybrid.KeyGen();
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek1, dk1] = hybrid.KeyGen();
+        return [ek0, dk0, ek1, dk1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_expanded_LEAK_BIND_K_PK.proof
@@ -65,13 +65,9 @@ Reduction R(KEM KEM_PQ, KEM KEM_T, KDF H, Label L, UK_expanded hybrid)
     hybrid.EncapsKey ek1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp0 = hybrid.KeyGen();
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp1 = hybrid.KeyGen();
-        ek0 = kp0[0];
-        dk0 = kp0[1];
-        ek1 = kp1[0];
-        dk1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek0, dk0] = hybrid.KeyGen();
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek1, dk1] = hybrid.KeyGen();
+        return [ek0, dk0, ek1, dk1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_Correctness.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_Correctness.proof
@@ -175,8 +175,7 @@ Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
     compose KEMCorrectness(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
         [KEM_T.EncapsKey, KEM_T.Ciphertext, KEM_T.SharedSecret, KEM_T.SharedSecret] [ek_T, ct_T, ss_T_e, ss_T_d] = challenger.Compute();
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nin> kdf_in_e = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_e) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nin> kdf_in_d = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T_d) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -189,10 +188,8 @@ Reduction R_KEM_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
 Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     compose KeyGenEquiv(KEM_T) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = challenger.Generate();
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_T.EncapsKey ek_T = t_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = challenger.Generate();
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -204,11 +201,9 @@ Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hy
 Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     compose KeyGenEquiv(KEM_PQ) against KEMCorrectness(hybrid).Adversary {
     [hybrid.EncapsKey, hybrid.Ciphertext, hybrid.SharedSecret, hybrid.SharedSecret] Compute() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = challenger.Generate();
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = challenger.Generate();
         BitString<KEM_T.Nseed> seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_T.EncapsKey ek_T = t_keys[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -223,10 +218,8 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         BitString<G.lambda + G.stretch> seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        KEM_T.EncapsKey ek_T = t_keys[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_PQ.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_PQ.proof
@@ -138,10 +138,8 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -154,13 +152,13 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ, c1);
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk_T, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(ek_PQ2) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -174,14 +172,10 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -191,13 +185,13 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ, c1);
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk_T, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(ek_PQ2) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -214,8 +208,7 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
         pq_keys = challenger.Generate();
         seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
@@ -246,13 +239,10 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
         pq_keys = challenger.Generate();
         seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -314,10 +304,8 @@ Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hy
         t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -385,8 +373,7 @@ Reduction R_Correct_Ideal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedb
         KEM_PQ.EncapsKey ek_PQ = corr[0];
         KEM_PQ.Ciphertext ct_PQ = corr[2];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -461,8 +448,7 @@ Game GameCaseSplitIdeal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbas
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         KEM_PQ.Ciphertext ct_PQ = kem_ct;
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -533,8 +519,7 @@ Reduction RC(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
         [KEM_PQ.EncapsKey, KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ek_PQ, ss_PQ, kem_ct] = challenger.Initialize();
         t_keys = KEM_T.KeyGen();
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -573,8 +558,7 @@ Reduction RD(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_PQ.EncodeCiphertext(kem_ct) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_T.EncodeSharedSecret(ss_T), rest);
@@ -610,10 +594,8 @@ Reduction RE(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -651,10 +633,8 @@ Game GameFreshSS(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybr
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] pq_enc = KEM_PQ.Encaps(ek_PQ);
-        kem_ct = pq_enc[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_unused, kem_ct] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [kem_ct, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_T.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_INDCCA_T.proof
@@ -145,10 +145,8 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || KEM_T.EncodeSharedSecret(ss_T) || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
@@ -161,13 +159,13 @@ Reduction R_PRG_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ, c1);
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk_T, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T2) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -181,14 +179,10 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         seed_full = challenger.Query();
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] _pq_kp_tmp = KEM_PQ.DeriveKeyPair(seed_PQ);
-        KEM_PQ.EncapsKey ek_PQ = _pq_kp_tmp[0];
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -198,13 +192,13 @@ Reduction R_PRG_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         if (c == ctStar) { return None; }
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keys = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keys = KEM_T.DeriveKeyPair(seed_T);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.Ciphertext c1 = c[0];
         KEM_T.Ciphertext c2 = c[1];
-        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(pq_keys[1], c1);
-        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(t_keys[1], c2);
-        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(pq_keys[0]) || KEM_T.EncodeEncapsKey(t_keys[0]) || L.get();
+        KEM_PQ.SharedSecret dec_ss_PQ = KEM_PQ.Decaps(dk_PQ, c1);
+        KEM_T.SharedSecret dec_ss_T = KEM_T.Decaps(dk_T, c2);
+        BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(dec_ss_PQ) || KEM_T.EncodeSharedSecret(dec_ss_T) || KEM_PQ.EncodeCiphertext(c1) || KEM_T.EncodeCiphertext(c2) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T2) || L.get();
         return H.evaluate(kdf_in);
     }
 }
@@ -218,8 +212,7 @@ Reduction R_KG_PQ_L(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
         pq_keys = challenger.Generate();
         seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
@@ -250,13 +243,10 @@ Reduction R_KG_PQ_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
     [hybrid.EncapsKey, hybrid.SharedSecret, hybrid.Ciphertext] Initialize() {
         pq_keys = challenger.Generate();
         seed_T <- BitString<KEM_T.Nseed>;
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] _t_kp_tmp = KEM_T.DeriveKeyPair(seed_T);
-        KEM_T.EncapsKey ek_T = _t_kp_tmp[0];
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -315,10 +305,8 @@ Reduction R_KG_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hy
         t_keys = challenger.Generate();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        KEM_T.Ciphertext ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -389,8 +377,7 @@ Reduction R_Correct_T_Ideal(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_see
         KEM_T.EncapsKey ek_T = corr[0];
         KEM_T.Ciphertext ct_T = corr[2];
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -505,8 +492,7 @@ Reduction R_KEM_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         [KEM_T.EncapsKey, KEM_T.SharedSecret, KEM_T.Ciphertext] [ek_T, ss_T_star, kem_ct_T] = challenger.Initialize();
         pq_keys = KEM_PQ.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -545,8 +531,7 @@ Game G_RandSS_T(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybri
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nin> kdf_in = KEM_PQ.EncodeSharedSecret(ss_PQ) || ss_T_star || KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = H.evaluate(kdf_in);
@@ -595,8 +580,7 @@ Reduction R_PRF_Fwd(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
         [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] t_enc = KEM_T.Encaps(ek_T);
-        kem_ct_T = t_enc[1];
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nin - (KEM_PQ.Nss + KEM_T.Nss)> rest = KEM_PQ.EncodeCiphertext(ct_PQ) || KEM_T.EncodeCiphertext(kem_ct_T) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
         BitString<H.Nout> ss = challenger.Lookup(KEM_PQ.EncodeSharedSecret(ss_PQ), rest);
         ctStar = [ct_PQ, kem_ct_T];
@@ -631,10 +615,8 @@ Reduction R_PRF_Rev(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -673,10 +655,8 @@ Game G_AllRand(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
         return [[ek_PQ, ek_T], ss, ctStar];
@@ -715,10 +695,8 @@ Game G_RandSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hyb
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
-        [KEM_T.SharedSecret, KEM_T.Ciphertext] _t_enc_tmp = KEM_T.Encaps(ek_T);
-        kem_ct_T = _t_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
+        [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T, kem_ct_T] = KEM_T.Encaps(ek_T);
         ss_T_star <- BitString<KEM_T.Nss>;
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];
@@ -757,8 +735,7 @@ Game G_StoredSS_T_R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased h
         t_keys = KEM_T.KeyGen();
         KEM_PQ.EncapsKey ek_PQ = pq_keys[0];
         KEM_T.EncapsKey ek_T = t_keys[0];
-        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] _pq_enc_tmp = KEM_PQ.Encaps(ek_PQ);
-        KEM_PQ.Ciphertext ct_PQ = _pq_enc_tmp[1];
+        [KEM_PQ.SharedSecret, KEM_PQ.Ciphertext] [ss_PQ, ct_PQ] = KEM_PQ.Encaps(ek_PQ);
         [KEM_T.SharedSecret, KEM_T.Ciphertext] [ss_T_star, kem_ct_T] = KEM_T.Encaps(ek_T);
         BitString<H.Nout> ss <- BitString<H.Nout>;
         ctStar = [ct_PQ, kem_ct_T];

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_LEAK_BIND_K_CT.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_LEAK_BIND_K_CT.proof
@@ -64,35 +64,33 @@ Reduction R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     BitString<G.lambda> seed1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp0 = hybrid.KeyGen();
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp1 = hybrid.KeyGen();
-        seed0 = kp0[1];
-        seed1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek0, seed0] = hybrid.KeyGen();
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek1, seed1] = hybrid.KeyGen();
+        return [ek0, seed0, ek1, seed1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {
         BitString<G.lambda + G.stretch> seed_full_0 = G.evaluate(seed0);
         BitString<KEM_PQ.Nseed> seed_PQ_0 = seed_full_0[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T_0 = seed_full_0[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(seed_PQ_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T_0);
         KEM_PQ.Ciphertext ct_PQ_0 = ct0[0];
         KEM_T.Ciphertext ct_T_0 = ct0[1];
-        KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(pq_kp_0[1], ct_PQ_0);
-        KEM_T.SharedSecret ss_T_0 = KEM_T.Decaps(t_kp_0[1], ct_T_0);
-        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || KEM_T.EncodeSharedSecret(ss_T_0) || KEM_PQ.EncodeCiphertext(ct_PQ_0) || KEM_T.EncodeCiphertext(ct_T_0) || KEM_PQ.EncodeEncapsKey(pq_kp_0[0]) || KEM_T.EncodeEncapsKey(t_kp_0[0]) || L.get();
+        KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(dk_PQ, ct_PQ_0);
+        KEM_T.SharedSecret ss_T_0 = KEM_T.Decaps(dk_T, ct_T_0);
+        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || KEM_T.EncodeSharedSecret(ss_T_0) || KEM_PQ.EncodeCiphertext(ct_PQ_0) || KEM_T.EncodeCiphertext(ct_T_0) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
 
         BitString<G.lambda + G.stretch> seed_full_1 = G.evaluate(seed1);
         BitString<KEM_PQ.Nseed> seed_PQ_1 = seed_full_1[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T_1 = seed_full_1[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(seed_PQ_1);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(seed_T_1);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ2] = KEM_PQ.DeriveKeyPair(seed_PQ_1);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_T2] = KEM_T.DeriveKeyPair(seed_T_1);
         KEM_PQ.Ciphertext ct_PQ_1 = ct1[0];
         KEM_T.Ciphertext ct_T_1 = ct1[1];
-        KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(pq_kp_1[1], ct_PQ_1);
-        KEM_T.SharedSecret ss_T_1 = KEM_T.Decaps(t_kp_1[1], ct_T_1);
-        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || KEM_T.EncodeSharedSecret(ss_T_1) || KEM_PQ.EncodeCiphertext(ct_PQ_1) || KEM_T.EncodeCiphertext(ct_T_1) || KEM_PQ.EncodeEncapsKey(pq_kp_1[0]) || KEM_T.EncodeEncapsKey(t_kp_1[0]) || L.get();
+        KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(dk_PQ2, ct_PQ_1);
+        KEM_T.SharedSecret ss_T_1 = KEM_T.Decaps(dk_T2, ct_T_1);
+        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || KEM_T.EncodeSharedSecret(ss_T_1) || KEM_PQ.EncodeCiphertext(ct_PQ_1) || KEM_T.EncodeCiphertext(ct_T_1) || KEM_PQ.EncodeEncapsKey(ek_PQ2) || KEM_T.EncodeEncapsKey(ek_T2) || L.get();
 
         if (ct0 == ct1) {
             return false;

--- a/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_LEAK_BIND_K_PK.proof
+++ b/applications/cfrg-hybrid-kems/proofs/UK/UK_seedbased_LEAK_BIND_K_PK.proof
@@ -66,37 +66,33 @@ Reduction R(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L, UK_seedbased hybrid)
     hybrid.EncapsKey ek1;
 
     [hybrid.EncapsKey, hybrid.DecapsKey, hybrid.EncapsKey, hybrid.DecapsKey] Initialize() {
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp0 = hybrid.KeyGen();
-        [hybrid.EncapsKey, hybrid.DecapsKey] kp1 = hybrid.KeyGen();
-        ek0 = kp0[0];
-        seed0 = kp0[1];
-        ek1 = kp1[0];
-        seed1 = kp1[1];
-        return [kp0[0], kp0[1], kp1[0], kp1[1]];
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek0, seed0] = hybrid.KeyGen();
+        [hybrid.EncapsKey, hybrid.DecapsKey] [ek1, seed1] = hybrid.KeyGen();
+        return [ek0, seed0, ek1, seed1];
     }
 
     Bool Challenge(hybrid.Ciphertext ct0, hybrid.Ciphertext ct1) {
         BitString<G.lambda + G.stretch> seed_full_0 = G.evaluate(seed0);
         BitString<KEM_PQ.Nseed> seed_PQ_0 = seed_full_0[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T_0 = seed_full_0[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_0 = KEM_PQ.DeriveKeyPair(seed_PQ_0);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_0 = KEM_T.DeriveKeyPair(seed_T_0);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ_0);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T_0);
         KEM_PQ.Ciphertext ct_PQ_0 = ct0[0];
         KEM_T.Ciphertext ct_T_0 = ct0[1];
-        KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(pq_kp_0[1], ct_PQ_0);
-        KEM_T.SharedSecret ss_T_0 = KEM_T.Decaps(t_kp_0[1], ct_T_0);
-        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || KEM_T.EncodeSharedSecret(ss_T_0) || KEM_PQ.EncodeCiphertext(ct_PQ_0) || KEM_T.EncodeCiphertext(ct_T_0) || KEM_PQ.EncodeEncapsKey(pq_kp_0[0]) || KEM_T.EncodeEncapsKey(t_kp_0[0]) || L.get();
+        KEM_PQ.SharedSecret ss_PQ_0 = KEM_PQ.Decaps(dk_PQ, ct_PQ_0);
+        KEM_T.SharedSecret ss_T_0 = KEM_T.Decaps(dk_T, ct_T_0);
+        BitString<H.Nin> kdf_in_0 = KEM_PQ.EncodeSharedSecret(ss_PQ_0) || KEM_T.EncodeSharedSecret(ss_T_0) || KEM_PQ.EncodeCiphertext(ct_PQ_0) || KEM_T.EncodeCiphertext(ct_T_0) || KEM_PQ.EncodeEncapsKey(ek_PQ) || KEM_T.EncodeEncapsKey(ek_T) || L.get();
 
         BitString<G.lambda + G.stretch> seed_full_1 = G.evaluate(seed1);
         BitString<KEM_PQ.Nseed> seed_PQ_1 = seed_full_1[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T_1 = seed_full_1[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_kp_1 = KEM_PQ.DeriveKeyPair(seed_PQ_1);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_kp_1 = KEM_T.DeriveKeyPair(seed_T_1);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ2, dk_PQ2] = KEM_PQ.DeriveKeyPair(seed_PQ_1);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T2, dk_T2] = KEM_T.DeriveKeyPair(seed_T_1);
         KEM_PQ.Ciphertext ct_PQ_1 = ct1[0];
         KEM_T.Ciphertext ct_T_1 = ct1[1];
-        KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(pq_kp_1[1], ct_PQ_1);
-        KEM_T.SharedSecret ss_T_1 = KEM_T.Decaps(t_kp_1[1], ct_T_1);
-        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || KEM_T.EncodeSharedSecret(ss_T_1) || KEM_PQ.EncodeCiphertext(ct_PQ_1) || KEM_T.EncodeCiphertext(ct_T_1) || KEM_PQ.EncodeEncapsKey(pq_kp_1[0]) || KEM_T.EncodeEncapsKey(t_kp_1[0]) || L.get();
+        KEM_PQ.SharedSecret ss_PQ_1 = KEM_PQ.Decaps(dk_PQ2, ct_PQ_1);
+        KEM_T.SharedSecret ss_T_1 = KEM_T.Decaps(dk_T2, ct_T_1);
+        BitString<H.Nin> kdf_in_1 = KEM_PQ.EncodeSharedSecret(ss_PQ_1) || KEM_T.EncodeSharedSecret(ss_T_1) || KEM_PQ.EncodeCiphertext(ct_PQ_1) || KEM_T.EncodeCiphertext(ct_T_1) || KEM_PQ.EncodeEncapsKey(ek_PQ2) || KEM_T.EncodeEncapsKey(ek_T2) || L.get();
 
         if (ek0 == ek1) {
             return false;

--- a/applications/cfrg-hybrid-kems/schemes/CG/CG_seedbased.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/CG/CG_seedbased.scheme
@@ -52,8 +52,7 @@ Scheme CG_seedbased(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(seed);
         BitString<K.Nseed> seed_PQ = seed_full[0 : K.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[K.Nseed : K.Nseed + NG.Nseed];
-        [K.EncapsKey, K.DecapsKey] kem_keypair = K.DeriveKeyPair(seed_PQ);
-        K.EncapsKey ek_PQ = kem_keypair[0];
+        [K.EncapsKey, K.DecapsKey] [ek_PQ, dk_PQ] = K.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         return [[ek_PQ, ek_T], seed];
@@ -133,8 +132,7 @@ Scheme CG_seedbased(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(dk);
         BitString<K.Nseed> seed_PQ = seed_full[0 : K.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[K.Nseed : K.Nseed + NG.Nseed];
-        [K.EncapsKey, K.DecapsKey] kem_keypair = K.DeriveKeyPair(seed_PQ);
-        K.DecapsKey dk_PQ = kem_keypair[1];
+        [K.EncapsKey, K.DecapsKey] [ek_PQ, dk_PQ] = K.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         K.Ciphertext ct_PQ = ct[0];

--- a/applications/cfrg-hybrid-kems/schemes/CK/CK_expanded.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/CK/CK_expanded.scheme
@@ -45,17 +45,17 @@ Scheme CK_expanded(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(seed);
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keypair = KEM_T.DeriveKeyPair(seed_T);
-        return [[pq_keypair[0], t_keypair[0]], [pq_keypair[1], t_keypair[1], t_keypair[0]]];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        return [[ek_PQ, ek_T], [dk_PQ, dk_T, ek_T]];
     }
 
     // Expanded-form KeyGen: component KeyGens called directly, with no
     // PRG / DeriveKeyPair indirection.
     [EncapsKey, DecapsKey] KeyGen() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keypair = KEM_T.KeyGen();
-        return [[pq_keypair[0], t_keypair[0]], [pq_keypair[1], t_keypair[1], t_keypair[0]]];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.KeyGen();
+        return [[ek_PQ, ek_T], [dk_PQ, dk_T, ek_T]];
     }
 
     // Encaps unchanged from CK_seedbased.

--- a/applications/cfrg-hybrid-kems/schemes/CK/CK_seedbased.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/CK/CK_seedbased.scheme
@@ -46,9 +46,9 @@ Scheme CK_seedbased(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(seed);
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keypair = KEM_T.DeriveKeyPair(seed_T);
-        return [[pq_keypair[0], t_keypair[0]], seed];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        return [[ek_PQ, ek_T], seed];
     }
 
     // Draft section 5.2:
@@ -118,9 +118,8 @@ Scheme CK_seedbased(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(dk);
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
         [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
-        KEM_PQ.DecapsKey dk_PQ = pq_keypair[1];
         KEM_PQ.Ciphertext ct_PQ = ct[0];
         KEM_T.Ciphertext ct_T = ct[1];
         KEM_PQ.SharedSecret ss_PQ = KEM_PQ.Decaps(dk_PQ, ct_PQ);

--- a/applications/cfrg-hybrid-kems/schemes/Helpers/SeededKEMWrapper.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/Helpers/SeededKEMWrapper.scheme
@@ -29,8 +29,8 @@ Scheme SeededKEMWrapper(KEM K_inner) extends KEM {
     Set DecapsKey = BitString<K_inner.Nseed>;
 
     deterministic [EncapsKey, DecapsKey] DeriveKeyPair(BitString<Nseed> seed) {
-        [K_inner.EncapsKey, K_inner.DecapsKey] kp = K_inner.DeriveKeyPair(seed);
-        return [kp[0], seed];
+        [K_inner.EncapsKey, K_inner.DecapsKey] [ek_inner, dk_inner] = K_inner.DeriveKeyPair(seed);
+        return [ek_inner, seed];
     }
 
     [EncapsKey, DecapsKey] KeyGen() {
@@ -43,8 +43,8 @@ Scheme SeededKEMWrapper(KEM K_inner) extends KEM {
     }
 
     deterministic SharedSecret Decaps(DecapsKey dk, Ciphertext ct) {
-        [K_inner.EncapsKey, K_inner.DecapsKey] kp = K_inner.DeriveKeyPair(dk);
-        return K_inner.Decaps(kp[1], ct);
+        [K_inner.EncapsKey, K_inner.DecapsKey] [ek_inner, dk_inner] = K_inner.DeriveKeyPair(dk);
+        return K_inner.Decaps(dk_inner, ct);
     }
 
     deterministic injective BitString<Nss> EncodeSharedSecret(SharedSecret ss) {

--- a/applications/cfrg-hybrid-kems/schemes/UG/UG_seedbased.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/UG/UG_seedbased.scheme
@@ -50,8 +50,7 @@ Scheme UG_seedbased(KEM K, NominalGroup NG, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(seed);
         BitString<K.Nseed> seed_PQ = seed_full[0 : K.Nseed];
         BitString<NG.Nseed> seed_T = seed_full[K.Nseed : K.Nseed + NG.Nseed];
-        [K.EncapsKey, K.DecapsKey] kem_keypair = K.DeriveKeyPair(seed_PQ);
-        K.EncapsKey ek_PQ = kem_keypair[0];
+        [K.EncapsKey, K.DecapsKey] [ek_PQ, dk_PQ] = K.DeriveKeyPair(seed_PQ);
         NG.Scalar dk_T = NG.RandomScalar(seed_T);
         NG.Element ek_T = NG.Exp(NG.Generator(), dk_T);
         return [[ek_PQ, ek_T], seed];

--- a/applications/cfrg-hybrid-kems/schemes/UK/UK_expanded.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/UK/UK_expanded.scheme
@@ -49,17 +49,17 @@ Scheme UK_expanded(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(seed);
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keypair = KEM_T.DeriveKeyPair(seed_T);
-        return [[pq_keypair[0], t_keypair[0]], [pq_keypair[1], t_keypair[1], pq_keypair[0], t_keypair[0]]];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        return [[ek_PQ, ek_T], [dk_PQ, dk_T, ek_PQ, ek_T]];
     }
 
     // Expanded-form KeyGen: component KeyGens called directly, with no
     // PRG / DeriveKeyPair indirection.
     [EncapsKey, DecapsKey] KeyGen() {
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.KeyGen();
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keypair = KEM_T.KeyGen();
-        return [[pq_keypair[0], t_keypair[0]], [pq_keypair[1], t_keypair[1], pq_keypair[0], t_keypair[0]]];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.KeyGen();
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.KeyGen();
+        return [[ek_PQ, ek_T], [dk_PQ, dk_T, ek_PQ, ek_T]];
     }
 
     // Encaps unchanged from UK_seedbased.

--- a/applications/cfrg-hybrid-kems/schemes/UK/UK_seedbased.scheme
+++ b/applications/cfrg-hybrid-kems/schemes/UK/UK_seedbased.scheme
@@ -44,9 +44,9 @@ Scheme UK_seedbased(KEM KEM_PQ, KEM KEM_T, PRG G, KDF H, Label L) extends KEM {
         BitString<G.lambda + G.stretch> seed_full = G.evaluate(seed);
         BitString<KEM_PQ.Nseed> seed_PQ = seed_full[0 : KEM_PQ.Nseed];
         BitString<KEM_T.Nseed> seed_T = seed_full[KEM_PQ.Nseed : KEM_PQ.Nseed + KEM_T.Nseed];
-        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] pq_keypair = KEM_PQ.DeriveKeyPair(seed_PQ);
-        [KEM_T.EncapsKey, KEM_T.DecapsKey] t_keypair = KEM_T.DeriveKeyPair(seed_T);
-        return [[pq_keypair[0], t_keypair[0]], seed];
+        [KEM_PQ.EncapsKey, KEM_PQ.DecapsKey] [ek_PQ, dk_PQ] = KEM_PQ.DeriveKeyPair(seed_PQ);
+        [KEM_T.EncapsKey, KEM_T.DecapsKey] [ek_T, dk_T] = KEM_T.DeriveKeyPair(seed_T);
+        return [[ek_PQ, ek_T], seed];
     }
 
     // Draft section 5.2:


### PR DESCRIPTION
Rewrite single-name tuple bindings that were only ever index-accessed into destructuring form: [K.EncapsKey, K.DecapsKey] keys = K.KeyGen() followed by keys[0]/keys[1] becomes [K.EncapsKey, K.DecapsKey] [ek, dk] = K.KeyGen(), dropping the separate index-read lines. Element names follow the local convention (ek/dk/ss/ct, with _PQ/_T or numeric suffixes where two instances coexist in one method).

The desugaring the engine already applies makes this purely cosmetic: every proof still verifies. The change also makes the rendered output read like the cryptographic literature.